### PR TITLE
Msbuild.version

### DIFF
--- a/src/Metropolis.Api/IO/UserPreferences.cs
+++ b/src/Metropolis.Api/IO/UserPreferences.cs
@@ -1,13 +1,17 @@
-using Metropolis.Api.IO.AutoSave;
+using System;
+using System.IO;
+using System.Linq;
 using Metropolis.Api.Properties;
 
 namespace Metropolis.Api.IO
 {
     public class UserPreferences : IUserPreferences
     {
+        string _msBuildPath;
+
         public bool ShowTipOfTheDay
         {
-            get { return (bool) Settings.Default["ShowTips"]; }
+            get { return (bool)Settings.Default["ShowTips"]; }
             set
             {
                 Settings.Default["ShowTips"] = value;
@@ -17,7 +21,7 @@ namespace Metropolis.Api.IO
 
         public string FxCopPath
         {
-            get { return (string) Settings.Default["FxCopPath"]; }
+            get { return (string)Settings.Default["FxCopPath"]; }
             set
             {
                 Settings.Default["FxCopPath"] = value;
@@ -27,13 +31,26 @@ namespace Metropolis.Api.IO
 
         public string MsBuildPath
         {
-            get { return (string) Settings.Default["MsBuildPath"]; }
-
-            set
+            get
             {
-                Settings.Default["MsBuildPath"] = value;
-                Settings.Default.Save();
+                if (_msBuildPath == null)
+                    InitMsBuildPath();
+
+                return _msBuildPath ?? Settings.Default.MSBuildPath;
             }
+
+            set { _msBuildPath = value; }
         }
+
+        void InitMsBuildPath()
+        {
+            var paths = Environment.GetEnvironmentVariable("PATH")?.Split(';');
+            var msbuildExe = "msbuild.exe";
+
+            var msBuildDirectory = paths?.FirstOrDefault(path => FileExists(path, msbuildExe));
+            _msBuildPath = Path.Combine(msBuildDirectory, msbuildExe);
+        }
+
+        bool FileExists(string path, string file) => File.Exists(Path.Combine(path.Trim(), file));
     }
 }

--- a/src/Metropolis.Api/IO/UserPreferences.cs
+++ b/src/Metropolis.Api/IO/UserPreferences.cs
@@ -36,7 +36,7 @@ namespace Metropolis.Api.IO
                 if (_msBuildPath == null)
                     InitMsBuildPath();
 
-                return _msBuildPath ?? Settings.Default.MSBuildPath;
+                return _msBuildPath ?? Settings.Default.MSBuildPathFallback;
             }
 
             set { _msBuildPath = value; }

--- a/src/Metropolis.Api/Properties/Settings.Designer.cs
+++ b/src/Metropolis.Api/Properties/Settings.Designer.cs
@@ -38,7 +38,7 @@ namespace Metropolis.Api.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("C:\\Program Files (x86)\\MSBuild\\14.0\\Bin\\MSBuild.exe")]
-        public string MSBuildPath {
+        public string MSBuildPathFallback {
             get {
                 return ((string)(this["MSBuildPath"]));
             }

--- a/src/Metropolis.Api/Properties/Settings.settings
+++ b/src/Metropolis.Api/Properties/Settings.settings
@@ -5,7 +5,7 @@
     <Setting Name="ShowTips" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="MSBuildPath" Type="System.String" Scope="User">
+    <Setting Name="MSBuildPathFallback" Type="System.String" Scope="User">
       <Value Profile="(Default)">C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe</Value>
     </Setting>
     <Setting Name="FxCopPath" Type="System.String" Scope="User">

--- a/src/Metropolis.Api/app.config
+++ b/src/Metropolis.Api/app.config
@@ -22,7 +22,7 @@
       <setting name="ShowTips" serializeAs="String">
         <value>True</value>
       </setting>
-      <setting name="MSBuildPath" serializeAs="String">
+      <setting name="MSBuildPathFallback" serializeAs="String">
         <value>C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe</value>
       </setting>
       <setting name="FxCopPath" serializeAs="String">

--- a/src/Metropolis.Cli.Console/Metropolis.Console.csproj
+++ b/src/Metropolis.Cli.Console/Metropolis.Console.csproj
@@ -67,6 +67,10 @@
       <Name>Metropolis.Common</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="NLog.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Metropolis.Cli.Console/MetropolisCLI.cs
+++ b/src/Metropolis.Cli.Console/MetropolisCLI.cs
@@ -30,11 +30,10 @@ namespace Metropolis.Console
                 else
                 {
                     System.Console.WriteLine("Metropolis expects you to have the following parameters: pathOfYamlConfigFile pathToProjectResultFile");
-                    System.Console.WriteLine(@"eg: metropolis.exe c:\ProjectFolder\project.yml c:\ProjectFolder\Results");
+                    System.Console.WriteLine(@"eg: metro.exe c:\ProjectFolder\project.yml c:\ProjectFolder\Results");
                     Environment.Exit(1);
                 }
 
-                System.Console.Write(@"Metropolis v0.0.1 - Command Usage: metropolis.exe csharp");
                 Environment.Exit(0);
             }
             catch (Exception e)

--- a/src/Metropolis.Cli.Console/NLog.config
+++ b/src/Metropolis.Cli.Console/NLog.config
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd"
+      autoReload="true"
+      throwExceptions="false"
+      internalLogLevel="Off" internalLogFile="c:\temp\nlog-internal.log">
+
+  <!-- optional, add some variables
+  https://github.com/nlog/NLog/wiki/Configuration-file#variables
+  -->
+  <variable name="myvar" value="myvalue"/>
+
+  <!--
+  See https://github.com/nlog/nlog/wiki/Configuration-file
+  for information on customizing logging rules and outputs.
+   -->
+  <targets>
+
+    <!--
+    add your targets here
+    See https://github.com/nlog/NLog/wiki/Targets for possible targets.
+    See https://github.com/nlog/NLog/wiki/Layout-Renderers for the possible layout renderers.
+    -->
+
+    <!--
+    Write events to a file with the date in the filename.
+    <target xsi:type="File" name="f" fileName="${basedir}/logs/${shortdate}.log"
+            layout="${longdate} ${uppercase:${level}} ${message}" />
+    -->
+
+    <target name="console" xsi:type="Console" />
+  </targets>
+
+  <rules>
+    <!-- add your logging rules here -->
+
+    <!--
+    Write all events with minimal level of Debug (So Debug, Info, Warn, Error and Fatal, but not Trace)  to "f"
+    <logger name="*" minlevel="Debug" writeTo="f" />
+    -->
+
+    <logger name="*" minlevel="Trace" writeTo="console" />
+  </rules>
+</nlog>


### PR DESCRIPTION
Add logging when running metropolis CLI.
Use msbuild.exe found in environment path variable. Fallback to msbuild.exe defined in app.config.