### PR TITLE
add three more ecmascript dialect: babel-react, react and node

### DIFF
--- a/Metropolis.sln
+++ b/Metropolis.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Metropolis", "src\Metropolis\Metropolis.csproj", "{B90DA606-DD50-4859-ADF0-EABBA51A57B1}"
 EndProject
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE = LICENSE
 		metro-install.ps1 = metro-install.ps1
 		metro-uninstall.ps1 = metro-uninstall.ps1
+		package.json = package.json
 		readme.md = readme.md
 	EndProjectSection
 EndProject

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "dist"
   ],
   "dependencies": {
-    "eslint": "~3.5.0",
-    "eslint-plugin-react": "~6.3.0",
+    "babel-eslint": "^7.2.3",
+    "eslint": "^4.4.1",
+    "eslint-plugin-react": "^7.2.1",
     "sloc": "~0.1.11"
   },
   "devDependencies": {

--- a/src/Metropolis.Api/Collection/Settings/babel_react.eslintrc.json
+++ b/src/Metropolis.Api/Collection/Settings/babel_react.eslintrc.json
@@ -1,0 +1,28 @@
+﻿{
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true
+  },
+  "extends": "eslint:recommended",
+
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "impliedStrict": true,
+      "jsx": true
+    }
+  },
+  "plugins": [
+    "react"
+  ],
+  "rules": {
+    "complexity": "error",
+    "max-depth": "error",
+    "max-params": "error",
+    "max-statements": "error",
+    "default-case": "error"
+  }
+}

--- a/src/Metropolis.Api/Collection/Settings/node.eslintrc.json
+++ b/src/Metropolis.Api/Collection/Settings/node.eslintrc.json
@@ -1,0 +1,19 @@
+﻿{
+  "parserOptions": {
+    "sourceType": "module"
+    //"ecmaFeatures": {
+    //  "experimentalObjectRestSpread": true
+    //}
+  },
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "rules": {
+    "max-statements": "error",
+    "max-params": "error",
+    "complexity": "error",
+    "max-depth": "error",
+    "default-case": "error"
+  }
+}

--- a/src/Metropolis.Api/Collection/Settings/react.eslintrc.json
+++ b/src/Metropolis.Api/Collection/Settings/react.eslintrc.json
@@ -1,0 +1,25 @@
+﻿{
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
+      "jsx": true
+    },
+    "sourceType": "module"
+  },
+  "plugins": [
+    "react"
+  ],
+  "rules": {
+    "complexity": "error",
+    "max-depth": "error",
+    "max-params": "error",
+    "max-statements": "error",
+    "default-case": "error"
+  }
+}

--- a/src/Metropolis.Api/Collection/Steps/ECMA/EsLintCollectionStep.cs
+++ b/src/Metropolis.Api/Collection/Steps/ECMA/EsLintCollectionStep.cs
@@ -10,7 +10,7 @@ namespace Metropolis.Api.Collection.Steps.ECMA
     public class EsLintCollectionStep : BaseCollectionStep
     {
         private readonly IFileSystem fileSystem;
-        private const string EsLintCommand = @"{0}eslint -c '{1}' '{2}\**' -o '{3}' -f checkstyle";
+        private const string EsLintCommand = @"{0}eslint -c '{1}' '{2}' --no-eslintrc -o '{3}' -f checkstyle {4}";
         private const string IgnorePathPart = " --ignore-path '{0}'";
 
         private static readonly Tuple<string,string> ParsingErrorKeyword =  new Tuple<string, string>("Parsing error: The keyword",
@@ -60,12 +60,19 @@ namespace Metropolis.Api.Collection.Steps.ECMA
         {
             var eslintConfigFile = GetEcmaDialect(args.EcmaScriptDialect);
 
-            var cmd = EsLintCommand.FormatWith(GetNodeBinPath(), LocateSettings(eslintConfigFile), args.SourceDirectory, result.MetricsFile);
+            var cmd = EsLintCommand.FormatWith(GetNodeBinPath(), LocateSettings(eslintConfigFile), args.SourceDirectory, result.MetricsFile,
+                GetFileExtensions(args.EcmaScriptDialect));
 
             if (args.IgnoreFile.IsNotEmpty())
                 cmd = string.Concat(cmd, IgnorePathPart.FormatWith(args.IgnoreFile));
 
             return cmd;
+        }
+
+        private static string GetFileExtensions(EslintPasringOptions eslintPasringOptions)
+        {
+            // if it is react, babel_react handle js and jsx files, otherwise just don't override the ext param, and let eslint do its default
+            return eslintPasringOptions == EslintPasringOptions.REACT  || eslintPasringOptions == EslintPasringOptions.BABEL_REACT ? " --ext .js,.jsx" : "";
         }
 
         private static string GetEcmaDialect(EslintPasringOptions eslintPasringOptions)
@@ -75,6 +82,12 @@ namespace Metropolis.Api.Collection.Steps.ECMA
                 fileName = "default.eslintrc.json";
             if (eslintPasringOptions == EslintPasringOptions.ECMA6)
                 fileName = "ecma6.eslintrc.json";
+            if (eslintPasringOptions == EslintPasringOptions.REACT)
+                fileName = "react.eslintrc.json";
+            if (eslintPasringOptions == EslintPasringOptions.BABEL_REACT)
+                fileName = "babel_react.eslintrc.json";
+            if (eslintPasringOptions == EslintPasringOptions.NODE)
+                fileName = "node.eslintrc.json";
             return fileName;
         }
     }

--- a/src/Metropolis.Api/Metropolis.Api.csproj
+++ b/src/Metropolis.Api/Metropolis.Api.csproj
@@ -214,7 +214,14 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <None Include="app.config" />
+    <Content Include="Collection\Settings\react.eslintrc.json" />
     <Content Include="NLog.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Collection\Settings\babel_react.eslintrc.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Collection\Settings\node.eslintrc.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <None Include="NLog.xsd">

--- a/src/Metropolis.Common/Models/EslintPasringOptions.cs
+++ b/src/Metropolis.Common/Models/EslintPasringOptions.cs
@@ -6,6 +6,6 @@
     /// </summary>
     public enum EslintPasringOptions
     {
-        DEFAULT, ECMA6
+        DEFAULT, ECMA6, REACT, BABEL_REACT, NODE
     }
 }

--- a/src/Metropolis.UI.MVVM.UWP/project.lock.json
+++ b/src/Metropolis.UI.MVVM.UWP/project.lock.json
@@ -1,9 +1,9 @@
 {
-  "locked": false,
-  "version": 1,
+  "version": 2,
   "targets": {
     "UAP,Version=v10.0": {
       "Microsoft.CSharp/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -30,6 +30,7 @@
         }
       },
       "Microsoft.NETCore/5.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.CSharp": "4.0.1",
           "Microsoft.NETCore.Platforms": "1.0.1",
@@ -88,8 +89,11 @@
           "System.Xml.XDocument": "4.0.11"
         }
       },
-      "Microsoft.NETCore.Jit/1.0.3": {},
+      "Microsoft.NETCore.Jit/1.0.3": {
+        "type": "package"
+      },
       "Microsoft.NETCore.Platforms/1.0.1": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.0/_._": {}
         },
@@ -98,6 +102,7 @@
         }
       },
       "Microsoft.NETCore.Portable.Compatibility/1.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
         },
@@ -186,12 +191,14 @@
         }
       },
       "Microsoft.NETCore.Runtime.CoreCLR/1.0.3": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Jit": "1.0.3",
           "Microsoft.NETCore.Windows.ApiSets": "1.0.1"
         }
       },
       "Microsoft.NETCore.Targets/1.0.2": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.0/_._": {}
         },
@@ -200,6 +207,7 @@
         }
       },
       "Microsoft.NETCore.UniversalWindowsPlatform/5.2.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore": "5.0.2",
           "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
@@ -235,8 +243,11 @@
           "System.Xml.XmlSerializer": "4.0.11"
         }
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {},
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {
+        "type": "package"
+      },
       "Microsoft.VisualBasic/10.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -263,6 +274,7 @@
         }
       },
       "Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -273,12 +285,14 @@
         }
       },
       "MvvmCross/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Binding": "4.3.0",
           "MvvmCross.Core": "4.3.0"
         }
       },
       "MvvmCross.Binding/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Core": "4.3.0"
         },
@@ -292,6 +306,7 @@
         }
       },
       "MvvmCross.Core/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Platform": "4.3.0"
         },
@@ -305,6 +320,7 @@
         }
       },
       "MvvmCross.Platform/4.3.0": {
+        "type": "package",
         "compile": {
           "lib/win81/MvvmCross.Platform.WindowsCommon.dll": {},
           "lib/win81/MvvmCross.Platform.dll": {}
@@ -315,6 +331,7 @@
         }
       },
       "runtime.native.System.IO.Compression/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1"
@@ -327,6 +344,7 @@
         }
       },
       "runtime.native.System.Security.Cryptography/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1"
@@ -339,6 +357,7 @@
         }
       },
       "System.AppContext/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -359,6 +378,7 @@
         }
       },
       "System.Buffers/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.1/_._": {}
         },
@@ -367,6 +387,7 @@
         }
       },
       "System.Collections/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -380,6 +401,7 @@
         }
       },
       "System.Collections.Concurrent/4.0.12": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -399,6 +421,7 @@
         }
       },
       "System.Collections.Immutable/1.2.0": {
+        "type": "package",
         "compile": {
           "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
         },
@@ -407,6 +430,7 @@
         }
       },
       "System.Collections.NonGeneric/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -423,6 +447,7 @@
         }
       },
       "System.Collections.Specialized/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.1",
           "System.Globalization": "4.0.11",
@@ -440,6 +465,7 @@
         }
       },
       "System.ComponentModel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -451,6 +477,7 @@
         }
       },
       "System.ComponentModel.Annotations/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.ComponentModel": "4.0.1",
@@ -472,6 +499,7 @@
         }
       },
       "System.ComponentModel.EventBasedAsync/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.1",
           "System.Runtime": "4.1.0",
@@ -486,6 +514,7 @@
         }
       },
       "System.Data.Common/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.2/System.Data.Common.dll": {}
         },
@@ -494,6 +523,7 @@
         }
       },
       "System.Diagnostics.Contracts/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -511,6 +541,7 @@
         }
       },
       "System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -524,6 +555,7 @@
         }
       },
       "System.Diagnostics.DiagnosticSource/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.3/_._": {}
         },
@@ -532,6 +564,7 @@
         }
       },
       "System.Diagnostics.StackTrace/4.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1"
         },
@@ -549,6 +582,7 @@
         }
       },
       "System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -562,6 +596,7 @@
         }
       },
       "System.Diagnostics.Tracing/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -575,6 +610,7 @@
         }
       },
       "System.Dynamic.Runtime/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -603,6 +639,7 @@
         }
       },
       "System.Globalization/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -616,6 +653,7 @@
         }
       },
       "System.Globalization.Calendars/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -627,6 +665,7 @@
         }
       },
       "System.Globalization.Extensions/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Globalization": "4.0.11",
@@ -650,6 +689,7 @@
         }
       },
       "System.IO/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -665,6 +705,7 @@
         }
       },
       "System.IO.Compression/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -697,6 +738,7 @@
         }
       },
       "System.IO.Compression.ZipFile/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Buffers": "4.0.0",
           "System.IO": "4.1.0",
@@ -716,6 +758,7 @@
         }
       },
       "System.IO.FileSystem/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -731,6 +774,7 @@
         }
       },
       "System.IO.FileSystem.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -742,6 +786,7 @@
         }
       },
       "System.IO.IsolatedStorage/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.IO.FileSystem": "4.0.1",
@@ -761,6 +806,7 @@
         }
       },
       "System.IO.UnmanagedMemoryStream/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.IO.FileSystem.Primitives": "4.0.1",
@@ -778,6 +824,7 @@
         }
       },
       "System.Linq/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -793,6 +840,7 @@
         }
       },
       "System.Linq.Expressions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -824,6 +872,7 @@
         }
       },
       "System.Linq.Parallel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Collections.Concurrent": "4.0.12",
@@ -844,6 +893,7 @@
         }
       },
       "System.Linq.Queryable/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -862,6 +912,7 @@
         }
       },
       "System.Net.Http/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -896,6 +947,7 @@
         }
       },
       "System.Net.Http.Rtc/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Net.Http": "4.1.0",
@@ -915,6 +967,7 @@
         }
       },
       "System.Net.NameResolution/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -944,6 +997,7 @@
         }
       },
       "System.Net.NetworkInformation/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.Win32.Primitives": "4.0.1",
@@ -981,6 +1035,7 @@
         }
       },
       "System.Net.Primitives/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -995,6 +1050,7 @@
         }
       },
       "System.Net.Requests/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Net.Primitives": "4.0.11",
@@ -1020,6 +1076,7 @@
         }
       },
       "System.Net.Sockets/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -1033,6 +1090,7 @@
         }
       },
       "System.Net.WebHeaderCollection/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -1047,6 +1105,7 @@
         }
       },
       "System.Net.WebSockets/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.1",
           "System.Resources.ResourceManager": "4.0.1",
@@ -1061,6 +1120,7 @@
         }
       },
       "System.Net.WebSockets.Client/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -1095,6 +1155,7 @@
         }
       },
       "System.Numerics.Vectors/4.1.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.0/System.Numerics.Vectors.dll": {}
         },
@@ -1103,6 +1164,7 @@
         }
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Numerics.Vectors": "4.1.1",
           "System.Runtime": "4.1.0",
@@ -1116,6 +1178,7 @@
         }
       },
       "System.ObjectModel/4.0.12": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -1131,6 +1194,7 @@
         }
       },
       "System.Private.DataContractSerialization/4.1.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -1170,6 +1234,7 @@
         }
       },
       "System.Private.ServiceModel/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -1233,6 +1298,7 @@
         }
       },
       "System.Reflection/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -1248,6 +1314,7 @@
         }
       },
       "System.Reflection.Context/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Runtime": "4.1.0"
@@ -1260,6 +1327,7 @@
         }
       },
       "System.Reflection.DispatchProxy/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Runtime": "4.1.0"
@@ -1278,6 +1346,7 @@
         }
       },
       "System.Reflection.Emit/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Reflection": "4.1.0",
@@ -1293,6 +1362,7 @@
         }
       },
       "System.Reflection.Emit.ILGeneration/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Reflection.Primitives": "4.0.1",
@@ -1312,6 +1382,7 @@
         }
       },
       "System.Reflection.Emit.Lightweight/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Reflection.Emit.ILGeneration": "4.0.1",
@@ -1332,6 +1403,7 @@
         }
       },
       "System.Reflection.Extensions/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -1346,6 +1418,7 @@
         }
       },
       "System.Reflection.Metadata/1.3.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections.Immutable": "1.2.0"
         },
@@ -1357,6 +1430,7 @@
         }
       },
       "System.Reflection.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -1370,6 +1444,7 @@
         }
       },
       "System.Reflection.TypeExtensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Contracts": "4.0.1",
           "System.Diagnostics.Debug": "4.0.11",
@@ -1394,6 +1469,7 @@
         }
       },
       "System.Resources.ResourceManager/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -1409,6 +1485,7 @@
         }
       },
       "System.Runtime/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1"
@@ -1421,6 +1498,7 @@
         }
       },
       "System.Runtime.Extensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -1434,6 +1512,7 @@
         }
       },
       "System.Runtime.Handles/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -1444,6 +1523,7 @@
         }
       },
       "System.Runtime.InteropServices/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -1460,6 +1540,7 @@
         }
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -1477,6 +1558,7 @@
         }
       },
       "System.Runtime.Numerics/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -1491,6 +1573,7 @@
         }
       },
       "System.Runtime.Serialization.Json/4.0.2": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Private.DataContractSerialization": "4.1.1",
@@ -1504,6 +1587,7 @@
         }
       },
       "System.Runtime.Serialization.Primitives/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.1",
           "System.Runtime": "4.1.0"
@@ -1522,6 +1606,7 @@
         }
       },
       "System.Runtime.Serialization.Xml/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Private.DataContractSerialization": "4.1.1",
@@ -1538,6 +1623,7 @@
         }
       },
       "System.Runtime.WindowsRuntime/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Diagnostics.Debug": "4.0.11",
@@ -1568,6 +1654,7 @@
         }
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Runtime.WindowsRuntime": "4.0.11"
@@ -1586,6 +1673,7 @@
         }
       },
       "System.Security.Claims/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -1603,6 +1691,7 @@
         }
       },
       "System.Security.Cryptography.Algorithms/4.2.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.IO": "4.1.0",
@@ -1626,6 +1715,7 @@
         }
       },
       "System.Security.Cryptography.Cng/4.2.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.IO": "4.1.0",
@@ -1650,6 +1740,7 @@
         }
       },
       "System.Security.Cryptography.Encoding/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -1679,6 +1770,7 @@
         }
       },
       "System.Security.Cryptography.Primitives/4.0.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -1696,6 +1788,7 @@
         }
       },
       "System.Security.Cryptography.X509Certificates/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -1727,6 +1820,7 @@
         }
       },
       "System.Security.Principal/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -1738,6 +1832,7 @@
         }
       },
       "System.ServiceModel.Duplex/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Private.ServiceModel": "4.1.0",
           "System.Runtime": "4.1.0",
@@ -1752,6 +1847,7 @@
         }
       },
       "System.ServiceModel.Http/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.11",
           "System.Net.WebHeaderCollection": "4.0.1",
@@ -1769,6 +1865,7 @@
         }
       },
       "System.ServiceModel.NetTcp/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.11",
           "System.Private.ServiceModel": "4.1.0",
@@ -1784,6 +1881,7 @@
         }
       },
       "System.ServiceModel.Primitives/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.ComponentModel.EventBasedAsync": "4.0.11",
@@ -1810,6 +1908,7 @@
         }
       },
       "System.ServiceModel.Security/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Private.ServiceModel": "4.1.0",
           "System.Runtime": "4.1.0",
@@ -1824,6 +1923,7 @@
         }
       },
       "System.Text.Encoding/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -1837,6 +1937,7 @@
         }
       },
       "System.Text.Encoding.CodePages/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -1866,6 +1967,7 @@
         }
       },
       "System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -1880,6 +1982,7 @@
         }
       },
       "System.Text.RegularExpressions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -1896,6 +1999,7 @@
         }
       },
       "System.Threading/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Threading.Tasks": "4.0.11"
@@ -1914,6 +2018,7 @@
         }
       },
       "System.Threading.Tasks/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -1927,6 +2032,7 @@
         }
       },
       "System.Threading.Tasks.Dataflow/4.6.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll": {}
         },
@@ -1935,6 +2041,7 @@
         }
       },
       "System.Threading.Tasks.Extensions/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/portable-net45+win8+wp8+wpa81/_._": {}
         },
@@ -1943,6 +2050,7 @@
         }
       },
       "System.Threading.Tasks.Parallel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.12",
           "System.Diagnostics.Debug": "4.0.11",
@@ -1961,6 +2069,7 @@
         }
       },
       "System.Threading.Timer/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -1974,6 +2083,7 @@
         }
       },
       "System.Xml.ReaderWriter/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -1999,6 +2109,7 @@
         }
       },
       "System.Xml.XDocument/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -2021,6 +2132,7 @@
         }
       },
       "System.Xml.XmlDocument/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -2041,6 +2153,7 @@
         }
       },
       "System.Xml.XmlSerializer/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -2072,10 +2185,14 @@
             "rid": "aot"
           }
         }
+      },
+      "Metropolis.UI.MVVM.Core/1.0.0": {
+        "type": "project"
       }
     },
     "UAP,Version=v10.0/win10-arm": {
       "Microsoft.CSharp/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -2102,6 +2219,7 @@
         }
       },
       "Microsoft.NETCore/5.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.CSharp": "4.0.1",
           "Microsoft.NETCore.Platforms": "1.0.1",
@@ -2160,8 +2278,11 @@
           "System.Xml.XDocument": "4.0.11"
         }
       },
-      "Microsoft.NETCore.Jit/1.0.3": {},
+      "Microsoft.NETCore.Jit/1.0.3": {
+        "type": "package"
+      },
       "Microsoft.NETCore.Platforms/1.0.1": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.0/_._": {}
         },
@@ -2170,6 +2291,7 @@
         }
       },
       "Microsoft.NETCore.Portable.Compatibility/1.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
         },
@@ -2204,6 +2326,7 @@
         }
       },
       "Microsoft.NETCore.Runtime.CoreCLR/1.0.3": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Jit": "1.0.3",
           "Microsoft.NETCore.Windows.ApiSets": "1.0.1",
@@ -2211,6 +2334,7 @@
         }
       },
       "Microsoft.NETCore.Targets/1.0.2": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.0/_._": {}
         },
@@ -2219,6 +2343,7 @@
         }
       },
       "Microsoft.NETCore.UniversalWindowsPlatform/5.2.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore": "5.0.2",
           "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
@@ -2254,8 +2379,11 @@
           "System.Xml.XmlSerializer": "4.0.11"
         }
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {},
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {
+        "type": "package"
+      },
       "Microsoft.VisualBasic/10.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -2282,6 +2410,7 @@
         }
       },
       "Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -2293,12 +2422,14 @@
         }
       },
       "MvvmCross/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Binding": "4.3.0",
           "MvvmCross.Core": "4.3.0"
         }
       },
       "MvvmCross.Binding/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Core": "4.3.0"
         },
@@ -2312,6 +2443,7 @@
         }
       },
       "MvvmCross.Core/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Platform": "4.3.0"
         },
@@ -2325,6 +2457,7 @@
         }
       },
       "MvvmCross.Platform/4.3.0": {
+        "type": "package",
         "compile": {
           "lib/win81/MvvmCross.Platform.WindowsCommon.dll": {},
           "lib/win81/MvvmCross.Platform.dll": {}
@@ -2335,6 +2468,7 @@
         }
       },
       "runtime.any.System.Collections/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -2346,6 +2480,7 @@
         }
       },
       "runtime.any.System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2354,6 +2489,7 @@
         }
       },
       "runtime.any.System.Diagnostics.Tracing/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2362,6 +2498,7 @@
         }
       },
       "runtime.any.System.Globalization/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2370,6 +2507,7 @@
         }
       },
       "runtime.any.System.Globalization.Calendars/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2378,6 +2516,7 @@
         }
       },
       "runtime.any.System.IO/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2386,6 +2525,7 @@
         }
       },
       "runtime.any.System.Reflection/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2394,6 +2534,7 @@
         }
       },
       "runtime.any.System.Reflection.Extensions/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2402,6 +2543,7 @@
         }
       },
       "runtime.any.System.Reflection.Primitives/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2410,6 +2552,7 @@
         }
       },
       "runtime.any.System.Resources.ResourceManager/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2418,6 +2561,7 @@
         }
       },
       "runtime.any.System.Runtime/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Private.Uri": "4.0.1"
         },
@@ -2429,6 +2573,7 @@
         }
       },
       "runtime.any.System.Runtime.Handles/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2437,6 +2582,7 @@
         }
       },
       "runtime.any.System.Runtime.InteropServices/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2445,6 +2591,7 @@
         }
       },
       "runtime.any.System.Text.Encoding/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2453,6 +2600,7 @@
         }
       },
       "runtime.any.System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2461,6 +2609,7 @@
         }
       },
       "runtime.any.System.Threading.Tasks/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2469,6 +2618,7 @@
         }
       },
       "runtime.any.System.Threading.Timer/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2477,6 +2627,7 @@
         }
       },
       "runtime.native.System.IO.Compression/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -2490,6 +2641,7 @@
         }
       },
       "runtime.native.System.Security.Cryptography/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1"
@@ -2502,6 +2654,7 @@
         }
       },
       "runtime.win.Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Runtime.InteropServices": "4.1.0"
@@ -2514,6 +2667,7 @@
         }
       },
       "runtime.win.System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2522,6 +2676,7 @@
         }
       },
       "runtime.win.System.IO.FileSystem/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -2547,6 +2702,7 @@
         }
       },
       "runtime.win.System.Net.Primitives/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.1",
           "System.Collections": "4.0.11",
@@ -2567,6 +2723,7 @@
         }
       },
       "runtime.win.System.Net.Sockets/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -2594,6 +2751,7 @@
         }
       },
       "runtime.win.System.Runtime.Extensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Private.Uri": "4.0.1"
         },
@@ -2605,6 +2763,7 @@
         }
       },
       "runtime.win7.System.Private.Uri/4.0.2": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -2613,6 +2772,7 @@
         }
       },
       "runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR/1.0.2": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.0/_._": {}
         },
@@ -2634,11 +2794,13 @@
         }
       },
       "runtime.win8-arm.runtime.native.System.IO.Compression/4.0.1": {
+        "type": "package",
         "native": {
           "runtimes/win8-arm/native/clrcompression.dll": {}
         }
       },
       "System.AppContext/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -2653,6 +2815,7 @@
         }
       },
       "System.Buffers/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.1/_._": {}
         },
@@ -2661,6 +2824,7 @@
         }
       },
       "System.Collections/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -2675,6 +2839,7 @@
         }
       },
       "System.Collections.Concurrent/4.0.12": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -2694,6 +2859,7 @@
         }
       },
       "System.Collections.Immutable/1.2.0": {
+        "type": "package",
         "compile": {
           "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
         },
@@ -2702,6 +2868,7 @@
         }
       },
       "System.Collections.NonGeneric/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -2718,6 +2885,7 @@
         }
       },
       "System.Collections.Specialized/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.1",
           "System.Globalization": "4.0.11",
@@ -2735,6 +2903,7 @@
         }
       },
       "System.ComponentModel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -2746,6 +2915,7 @@
         }
       },
       "System.ComponentModel.Annotations/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.ComponentModel": "4.0.1",
@@ -2767,6 +2937,7 @@
         }
       },
       "System.ComponentModel.EventBasedAsync/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.1",
           "System.Runtime": "4.1.0",
@@ -2781,6 +2952,7 @@
         }
       },
       "System.Data.Common/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.2/System.Data.Common.dll": {}
         },
@@ -2789,6 +2961,7 @@
         }
       },
       "System.Diagnostics.Contracts/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -2800,6 +2973,7 @@
         }
       },
       "System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -2814,6 +2988,7 @@
         }
       },
       "System.Diagnostics.DiagnosticSource/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.3/_._": {}
         },
@@ -2822,6 +2997,7 @@
         }
       },
       "System.Diagnostics.StackTrace/4.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1"
         },
@@ -2833,6 +3009,7 @@
         }
       },
       "System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -2847,6 +3024,7 @@
         }
       },
       "System.Diagnostics.Tracing/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -2861,6 +3039,7 @@
         }
       },
       "System.Dynamic.Runtime/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -2883,6 +3062,7 @@
         }
       },
       "System.Globalization/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -2897,6 +3077,7 @@
         }
       },
       "System.Globalization.Calendars/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -2909,6 +3090,7 @@
         }
       },
       "System.Globalization.Extensions/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Globalization": "4.0.11",
@@ -2925,6 +3107,7 @@
         }
       },
       "System.IO/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -2941,6 +3124,7 @@
         }
       },
       "System.IO.Compression/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -2963,6 +3147,7 @@
         }
       },
       "System.IO.Compression.ZipFile/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Buffers": "4.0.0",
           "System.IO": "4.1.0",
@@ -2982,6 +3167,7 @@
         }
       },
       "System.IO.FileSystem/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -2998,6 +3184,7 @@
         }
       },
       "System.IO.FileSystem.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -3009,6 +3196,7 @@
         }
       },
       "System.IO.IsolatedStorage/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.IO.FileSystem": "4.0.1",
@@ -3028,6 +3216,7 @@
         }
       },
       "System.IO.UnmanagedMemoryStream/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.IO.FileSystem.Primitives": "4.0.1",
@@ -3045,6 +3234,7 @@
         }
       },
       "System.Linq/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -3060,6 +3250,7 @@
         }
       },
       "System.Linq.Expressions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -3085,6 +3276,7 @@
         }
       },
       "System.Linq.Parallel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Collections.Concurrent": "4.0.12",
@@ -3105,6 +3297,7 @@
         }
       },
       "System.Linq.Queryable/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -3123,6 +3316,7 @@
         }
       },
       "System.Net.Http/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -3151,6 +3345,7 @@
         }
       },
       "System.Net.Http.Rtc/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Net.Http": "4.1.0",
@@ -3164,6 +3359,7 @@
         }
       },
       "System.Net.NameResolution/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -3186,6 +3382,7 @@
         }
       },
       "System.Net.NetworkInformation/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.Win32.Primitives": "4.0.1",
@@ -3209,6 +3406,7 @@
         }
       },
       "System.Net.Primitives/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -3224,6 +3422,7 @@
         }
       },
       "System.Net.Requests/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Net.Primitives": "4.0.11",
@@ -3239,6 +3438,7 @@
         }
       },
       "System.Net.Sockets/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -3253,6 +3453,7 @@
         }
       },
       "System.Net.WebHeaderCollection/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -3267,6 +3468,7 @@
         }
       },
       "System.Net.WebSockets/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.1",
           "System.Resources.ResourceManager": "4.0.1",
@@ -3281,6 +3483,7 @@
         }
       },
       "System.Net.WebSockets.Client/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -3308,6 +3511,7 @@
         }
       },
       "System.Numerics.Vectors/4.1.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.0/System.Numerics.Vectors.dll": {}
         },
@@ -3316,6 +3520,7 @@
         }
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Numerics.Vectors": "4.1.1",
           "System.Runtime": "4.1.0",
@@ -3329,6 +3534,7 @@
         }
       },
       "System.ObjectModel/4.0.12": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -3344,6 +3550,7 @@
         }
       },
       "System.Private.DataContractSerialization/4.1.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -3377,6 +3584,7 @@
         }
       },
       "System.Private.ServiceModel/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -3433,6 +3641,7 @@
         }
       },
       "System.Private.Uri/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -3443,6 +3652,7 @@
         }
       },
       "System.Reflection/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -3459,6 +3669,7 @@
         }
       },
       "System.Reflection.Context/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Runtime": "4.1.0"
@@ -3471,6 +3682,7 @@
         }
       },
       "System.Reflection.DispatchProxy/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Runtime": "4.1.0"
@@ -3483,6 +3695,7 @@
         }
       },
       "System.Reflection.Emit/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Reflection": "4.1.0",
@@ -3498,6 +3711,7 @@
         }
       },
       "System.Reflection.Emit.ILGeneration/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Reflection.Primitives": "4.0.1",
@@ -3511,6 +3725,7 @@
         }
       },
       "System.Reflection.Emit.Lightweight/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Reflection.Emit.ILGeneration": "4.0.1",
@@ -3525,6 +3740,7 @@
         }
       },
       "System.Reflection.Extensions/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -3540,6 +3756,7 @@
         }
       },
       "System.Reflection.Metadata/1.3.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections.Immutable": "1.2.0"
         },
@@ -3551,6 +3768,7 @@
         }
       },
       "System.Reflection.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -3565,6 +3783,7 @@
         }
       },
       "System.Reflection.TypeExtensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Contracts": "4.0.1",
           "System.Diagnostics.Debug": "4.0.11",
@@ -3583,6 +3802,7 @@
         }
       },
       "System.Resources.ResourceManager/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -3599,6 +3819,7 @@
         }
       },
       "System.Runtime/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -3612,6 +3833,7 @@
         }
       },
       "System.Runtime.Extensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -3626,6 +3848,7 @@
         }
       },
       "System.Runtime.Handles/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -3637,6 +3860,7 @@
         }
       },
       "System.Runtime.InteropServices/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -3654,6 +3878,7 @@
         }
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -3665,6 +3890,7 @@
         }
       },
       "System.Runtime.Numerics/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -3679,6 +3905,7 @@
         }
       },
       "System.Runtime.Serialization.Json/4.0.2": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Private.DataContractSerialization": "4.1.1",
@@ -3692,6 +3919,7 @@
         }
       },
       "System.Runtime.Serialization.Primitives/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.1",
           "System.Runtime": "4.1.0"
@@ -3704,6 +3932,7 @@
         }
       },
       "System.Runtime.Serialization.Xml/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Private.DataContractSerialization": "4.1.1",
@@ -3720,6 +3949,7 @@
         }
       },
       "System.Runtime.WindowsRuntime/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Diagnostics.Debug": "4.0.11",
@@ -3740,6 +3970,7 @@
         }
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Runtime.WindowsRuntime": "4.0.11"
@@ -3752,6 +3983,7 @@
         }
       },
       "System.Security.Claims/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -3769,6 +4001,7 @@
         }
       },
       "System.Security.Cryptography.Algorithms/4.2.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.IO": "4.1.0",
@@ -3789,6 +4022,7 @@
         }
       },
       "System.Security.Cryptography.Cng/4.2.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.IO": "4.1.0",
@@ -3810,6 +4044,7 @@
         }
       },
       "System.Security.Cryptography.Encoding/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -3832,6 +4067,7 @@
         }
       },
       "System.Security.Cryptography.Primitives/4.0.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -3849,6 +4085,7 @@
         }
       },
       "System.Security.Cryptography.X509Certificates/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -3877,6 +4114,7 @@
         }
       },
       "System.Security.Principal/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -3888,6 +4126,7 @@
         }
       },
       "System.ServiceModel.Duplex/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Private.ServiceModel": "4.1.0",
           "System.Runtime": "4.1.0",
@@ -3902,6 +4141,7 @@
         }
       },
       "System.ServiceModel.Http/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.11",
           "System.Net.WebHeaderCollection": "4.0.1",
@@ -3919,6 +4159,7 @@
         }
       },
       "System.ServiceModel.NetTcp/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.11",
           "System.Private.ServiceModel": "4.1.0",
@@ -3934,6 +4175,7 @@
         }
       },
       "System.ServiceModel.Primitives/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.ComponentModel.EventBasedAsync": "4.0.11",
@@ -3960,6 +4202,7 @@
         }
       },
       "System.ServiceModel.Security/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Private.ServiceModel": "4.1.0",
           "System.Runtime": "4.1.0",
@@ -3974,6 +4217,7 @@
         }
       },
       "System.Text.Encoding/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -3988,6 +4232,7 @@
         }
       },
       "System.Text.Encoding.CodePages/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -4010,6 +4255,7 @@
         }
       },
       "System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -4025,6 +4271,7 @@
         }
       },
       "System.Text.RegularExpressions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -4041,6 +4288,7 @@
         }
       },
       "System.Threading/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Threading.Tasks": "4.0.11"
@@ -4053,6 +4301,7 @@
         }
       },
       "System.Threading.Overlapped/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Resources.ResourceManager": "4.0.1",
@@ -4070,6 +4319,7 @@
         }
       },
       "System.Threading.Tasks/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -4084,6 +4334,7 @@
         }
       },
       "System.Threading.Tasks.Dataflow/4.6.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll": {}
         },
@@ -4092,6 +4343,7 @@
         }
       },
       "System.Threading.Tasks.Extensions/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/portable-net45+win8+wp8+wpa81/_._": {}
         },
@@ -4100,6 +4352,7 @@
         }
       },
       "System.Threading.Tasks.Parallel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.12",
           "System.Diagnostics.Debug": "4.0.11",
@@ -4118,6 +4371,7 @@
         }
       },
       "System.Threading.Timer/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -4132,6 +4386,7 @@
         }
       },
       "System.Xml.ReaderWriter/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -4157,6 +4412,7 @@
         }
       },
       "System.Xml.XDocument/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -4179,6 +4435,7 @@
         }
       },
       "System.Xml.XmlDocument/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -4199,6 +4456,7 @@
         }
       },
       "System.Xml.XmlSerializer/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -4224,10 +4482,14 @@
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
+      },
+      "Metropolis.UI.MVVM.Core/1.0.0": {
+        "type": "project"
       }
     },
     "UAP,Version=v10.0/win10-arm-aot": {
       "Microsoft.CSharp/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -4254,2197 +4516,7 @@
         }
       },
       "Microsoft.NETCore/5.0.2": {
-        "dependencies": {
-          "Microsoft.CSharp": "4.0.1",
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.VisualBasic": "10.0.1",
-          "System.AppContext": "4.1.0",
-          "System.Collections": "4.0.11",
-          "System.Collections.Concurrent": "4.0.12",
-          "System.Collections.Immutable": "1.2.0",
-          "System.ComponentModel": "4.0.1",
-          "System.ComponentModel.Annotations": "4.1.0",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Diagnostics.Tools": "4.0.1",
-          "System.Diagnostics.Tracing": "4.1.0",
-          "System.Dynamic.Runtime": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.Globalization.Calendars": "4.0.1",
-          "System.Globalization.Extensions": "4.0.1",
-          "System.IO": "4.1.0",
-          "System.IO.Compression": "4.1.1",
-          "System.IO.Compression.ZipFile": "4.0.1",
-          "System.IO.FileSystem": "4.0.1",
-          "System.IO.FileSystem.Primitives": "4.0.1",
-          "System.IO.UnmanagedMemoryStream": "4.0.1",
-          "System.Linq": "4.1.0",
-          "System.Linq.Expressions": "4.1.0",
-          "System.Linq.Parallel": "4.0.1",
-          "System.Linq.Queryable": "4.0.1",
-          "System.Net.Http": "4.1.0",
-          "System.Net.NetworkInformation": "4.1.0",
-          "System.Net.Primitives": "4.0.11",
-          "System.Numerics.Vectors": "4.1.1",
-          "System.ObjectModel": "4.0.12",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.DispatchProxy": "4.0.1",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Reflection.Metadata": "1.3.0",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Runtime.Numerics": "4.0.1",
-          "System.Security.Claims": "4.0.1",
-          "System.Security.Principal": "4.0.1",
-          "System.Text.Encoding": "4.0.11",
-          "System.Text.Encoding.Extensions": "4.0.11",
-          "System.Text.RegularExpressions": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11",
-          "System.Threading.Tasks.Dataflow": "4.6.0",
-          "System.Threading.Tasks.Parallel": "4.0.1",
-          "System.Threading.Timer": "4.0.1",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XDocument": "4.0.11"
-        }
-      },
-      "Microsoft.NETCore.Jit/1.0.3": {},
-      "Microsoft.NETCore.Platforms/1.0.1": {
-        "compile": {
-          "lib/netstandard1.0/_._": {}
-        },
-        "runtime": {
-          "lib/netstandard1.0/_._": {}
-        }
-      },
-      "Microsoft.NETCore.Portable.Compatibility/1.0.2": {
-        "dependencies": {
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
-        },
-        "compile": {
-          "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
-          "ref/netcore50/System.Core.dll": {},
-          "ref/netcore50/System.Net.dll": {},
-          "ref/netcore50/System.Numerics.dll": {},
-          "ref/netcore50/System.Runtime.Serialization.dll": {},
-          "ref/netcore50/System.ServiceModel.Web.dll": {},
-          "ref/netcore50/System.ServiceModel.dll": {},
-          "ref/netcore50/System.Windows.dll": {},
-          "ref/netcore50/System.Xml.Linq.dll": {},
-          "ref/netcore50/System.Xml.Serialization.dll": {},
-          "ref/netcore50/System.Xml.dll": {},
-          "ref/netcore50/System.dll": {},
-          "ref/netcore50/mscorlib.dll": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
-          "runtimes/aot/lib/netcore50/System.Core.dll": {},
-          "runtimes/aot/lib/netcore50/System.Net.dll": {},
-          "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
-          "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
-          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
-          "runtimes/aot/lib/netcore50/System.Windows.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
-          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
-          "runtimes/aot/lib/netcore50/System.dll": {},
-          "runtimes/aot/lib/netcore50/mscorlib.dll": {}
-        }
-      },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.3": {
-        "dependencies": {
-          "Microsoft.NETCore.Jit": "1.0.3",
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1",
-          "runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
-        }
-      },
-      "Microsoft.NETCore.Targets/1.0.2": {
-        "compile": {
-          "lib/netstandard1.0/_._": {}
-        },
-        "runtime": {
-          "lib/netstandard1.0/_._": {}
-        }
-      },
-      "Microsoft.NETCore.UniversalWindowsPlatform/5.2.2": {
-        "dependencies": {
-          "Microsoft.NETCore": "5.0.2",
-          "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.3",
-          "Microsoft.NETCore.Targets": "1.0.2",
-          "Microsoft.Win32.Primitives": "4.0.1",
-          "System.ComponentModel.EventBasedAsync": "4.0.11",
-          "System.Data.Common": "4.1.0",
-          "System.Diagnostics.Contracts": "4.0.1",
-          "System.Diagnostics.StackTrace": "4.0.2",
-          "System.IO.IsolatedStorage": "4.0.1",
-          "System.Net.Http.Rtc": "4.0.1",
-          "System.Net.NameResolution": "4.0.0",
-          "System.Net.Requests": "4.0.11",
-          "System.Net.Sockets": "4.1.0",
-          "System.Net.WebHeaderCollection": "4.0.1",
-          "System.Net.WebSockets": "4.0.0",
-          "System.Net.WebSockets.Client": "4.0.0",
-          "System.Numerics.Vectors.WindowsRuntime": "4.0.1",
-          "System.Reflection.Context": "4.0.1",
-          "System.Runtime.InteropServices.WindowsRuntime": "4.0.1",
-          "System.Runtime.Serialization.Json": "4.0.2",
-          "System.Runtime.Serialization.Primitives": "4.1.1",
-          "System.Runtime.Serialization.Xml": "4.1.1",
-          "System.Runtime.WindowsRuntime": "4.0.11",
-          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.1",
-          "System.ServiceModel.Duplex": "4.0.1",
-          "System.ServiceModel.Http": "4.1.0",
-          "System.ServiceModel.NetTcp": "4.1.0",
-          "System.ServiceModel.Primitives": "4.1.0",
-          "System.ServiceModel.Security": "4.0.1",
-          "System.Text.Encoding.CodePages": "4.0.1",
-          "System.Xml.XmlSerializer": "4.0.11"
-        }
-      },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {},
-      "Microsoft.VisualBasic/10.0.1": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Dynamic.Runtime": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.Linq": "4.1.0",
-          "System.Linq.Expressions": "4.1.0",
-          "System.ObjectModel": "4.0.12",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/Microsoft.VisualBasic.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/Microsoft.VisualBasic.dll": {}
-        }
-      },
-      "Microsoft.Win32.Primitives/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.win.Microsoft.Win32.Primitives": "4.0.1"
-        },
-        "compile": {
-          "ref/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
-        }
-      },
-      "MvvmCross/4.3.0": {
-        "dependencies": {
-          "MvvmCross.Binding": "4.3.0",
-          "MvvmCross.Core": "4.3.0"
-        }
-      },
-      "MvvmCross.Binding/4.3.0": {
-        "dependencies": {
-          "MvvmCross.Core": "4.3.0"
-        },
-        "compile": {
-          "lib/win81/MvvmCross.Binding.dll": {},
-          "lib/win81/MvvmCross.Localization.dll": {}
-        },
-        "runtime": {
-          "lib/win81/MvvmCross.Binding.dll": {},
-          "lib/win81/MvvmCross.Localization.dll": {}
-        }
-      },
-      "MvvmCross.Core/4.3.0": {
-        "dependencies": {
-          "MvvmCross.Platform": "4.3.0"
-        },
-        "compile": {
-          "lib/uap/MvvmCross.Core.dll": {},
-          "lib/uap/MvvmCross.WindowsUWP.dll": {}
-        },
-        "runtime": {
-          "lib/uap/MvvmCross.Core.dll": {},
-          "lib/uap/MvvmCross.WindowsUWP.dll": {}
-        }
-      },
-      "MvvmCross.Platform/4.3.0": {
-        "compile": {
-          "lib/win81/MvvmCross.Platform.WindowsCommon.dll": {},
-          "lib/win81/MvvmCross.Platform.dll": {}
-        },
-        "runtime": {
-          "lib/win81/MvvmCross.Platform.WindowsCommon.dll": {},
-          "lib/win81/MvvmCross.Platform.dll": {}
-        }
-      },
-      "runtime.aot.System.Collections/4.0.10": {
-        "dependencies": {
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Collections.dll": {}
-        }
-      },
-      "runtime.aot.System.Diagnostics.Tools/4.0.1": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Diagnostics.Tools.dll": {}
-        }
-      },
-      "runtime.aot.System.Diagnostics.Tracing/4.0.20": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Text.Encoding": "4.0.11",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Diagnostics.Tracing.dll": {}
-        }
-      },
-      "runtime.aot.System.Globalization/4.0.11": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Globalization.dll": {}
-        }
-      },
-      "runtime.aot.System.Globalization.Calendars/4.0.1": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Globalization.Calendars.dll": {}
-        }
-      },
-      "runtime.aot.System.IO/4.1.0": {
-        "dependencies": {
-          "System.Globalization": "4.0.11",
-          "System.Runtime": "4.1.0",
-          "System.Text.Encoding": "4.0.11",
-          "System.Text.Encoding.Extensions": "4.0.11",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.IO.dll": {}
-        }
-      },
-      "runtime.aot.System.Reflection/4.0.10": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Reflection.dll": {}
-        }
-      },
-      "runtime.aot.System.Reflection.Extensions/4.0.0": {
-        "dependencies": {
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Reflection.Extensions.dll": {}
-        }
-      },
-      "runtime.aot.System.Reflection.Primitives/4.0.0": {
-        "dependencies": {
-          "System.Runtime": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Reflection.Primitives.dll": {}
-        }
-      },
-      "runtime.aot.System.Resources.ResourceManager/4.0.0": {
-        "dependencies": {
-          "System.Globalization": "4.0.11",
-          "System.Reflection": "4.1.0",
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Resources.ResourceManager.dll": {}
-        }
-      },
-      "runtime.aot.System.Runtime/4.0.20": {
-        "dependencies": {
-          "System.Private.Uri": "4.0.1"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Runtime.dll": {}
-        }
-      },
-      "runtime.aot.System.Runtime.Handles/4.0.1": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Runtime.Handles.dll": {}
-        }
-      },
-      "runtime.aot.System.Runtime.InteropServices/4.0.20": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Runtime.InteropServices.dll": {}
-        }
-      },
-      "runtime.aot.System.Text.Encoding/4.0.11": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Text.Encoding.dll": {}
-        }
-      },
-      "runtime.aot.System.Text.Encoding.Extensions/4.0.11": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Text.Encoding.Extensions.dll": {}
-        }
-      },
-      "runtime.aot.System.Threading.Tasks/4.0.11": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "runtime.aot.System.Threading.Timer/4.0.1": {
-        "dependencies": {
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Threading.Timer.dll": {}
-        }
-      },
-      "runtime.native.System.IO.Compression/4.1.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "runtime.win10-arm-aot.runtime.native.System.IO.Compression": "4.0.1"
-        },
-        "compile": {
-          "lib/netstandard1.0/_._": {}
-        },
-        "runtime": {
-          "lib/netstandard1.0/_._": {}
-        }
-      },
-      "runtime.native.System.Security.Cryptography/4.0.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1"
-        },
-        "compile": {
-          "lib/netstandard1.0/_._": {}
-        },
-        "runtime": {
-          "lib/netstandard1.0/_._": {}
-        }
-      },
-      "runtime.win.Microsoft.Win32.Primitives/4.0.1": {
-        "dependencies": {
-          "System.Runtime": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
-        }
-      },
-      "runtime.win.System.Diagnostics.Debug/4.0.11": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Diagnostics.Debug.dll": {}
-        }
-      },
-      "runtime.win.System.IO.FileSystem/4.0.1": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.IO.FileSystem.Primitives": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Runtime.WindowsRuntime": "4.0.11",
-          "System.Text.Encoding": "4.0.11",
-          "System.Text.Encoding.Extensions": "4.0.11",
-          "System.Threading": "4.0.11",
-          "System.Threading.Overlapped": "4.0.1",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netcore50/System.IO.FileSystem.dll": {}
-        }
-      },
-      "runtime.win.System.Net.Primitives/4.0.11": {
-        "dependencies": {
-          "Microsoft.Win32.Primitives": "4.0.1",
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Tracing": "4.1.0",
-          "System.Globalization": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netcore50/System.Net.Primitives.dll": {}
-        }
-      },
-      "runtime.win.System.Net.Sockets/4.1.0": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Diagnostics.Tracing": "4.1.0",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.IO.FileSystem": "4.0.1",
-          "System.IO.FileSystem.Primitives": "4.0.1",
-          "System.Net.NameResolution": "4.0.0",
-          "System.Net.Primitives": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Overlapped": "4.0.1",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netcore50/System.Net.Sockets.dll": {}
-        }
-      },
-      "runtime.win.System.Runtime.Extensions/4.1.0": {
-        "dependencies": {
-          "System.Private.Uri": "4.0.1"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Runtime.Extensions.dll": {}
-        }
-      },
-      "runtime.win10-arm-aot.runtime.native.System.IO.Compression/4.0.1": {
-        "compile": {
-          "runtimes/win10-arm-aot/lib/netcore50/_._": {}
-        },
-        "runtime": {
-          "runtimes/win10-arm-aot/lib/netcore50/clrcompression.dll": {}
-        }
-      },
-      "runtime.win7.System.Private.Uri/4.0.2": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Private.Uri.dll": {}
-        }
-      },
-      "runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR/1.0.2": {
-        "compile": {
-          "ref/netstandard1.0/_._": {}
-        },
-        "runtime": {
-          "runtimes/win8-arm-aot/lib/netstandard1.0/_._": {}
-        },
-        "native": {
-          "runtimes/win8-arm-aot/native/_._": {}
-        }
-      },
-      "System.AppContext/4.1.0": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.AppContext.dll": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.AppContext.dll": {}
-        }
-      },
-      "System.Buffers/4.0.0": {
-        "compile": {
-          "lib/netstandard1.1/_._": {}
-        },
-        "runtime": {
-          "lib/netstandard1.1/System.Buffers.dll": {}
-        }
-      },
-      "System.Collections/4.0.11": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Collections": "4.0.10"
-        },
-        "compile": {
-          "ref/netcore50/System.Collections.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Collections.Concurrent/4.0.12": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Diagnostics.Tracing": "4.1.0",
-          "System.Globalization": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Collections.Concurrent.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Collections.Concurrent.dll": {}
-        }
-      },
-      "System.Collections.Immutable/1.2.0": {
-        "compile": {
-          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
-        }
-      },
-      "System.Collections.NonGeneric/4.0.1": {
-        "dependencies": {
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.3/_._": {}
-        },
-        "runtime": {
-          "lib/netstandard1.3/System.Collections.NonGeneric.dll": {}
-        }
-      },
-      "System.Collections.Specialized/4.0.1": {
-        "dependencies": {
-          "System.Collections.NonGeneric": "4.0.1",
-          "System.Globalization": "4.0.11",
-          "System.Globalization.Extensions": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.3/_._": {}
-        },
-        "runtime": {
-          "lib/netstandard1.3/System.Collections.Specialized.dll": {}
-        }
-      },
-      "System.ComponentModel/4.0.1": {
-        "dependencies": {
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.ComponentModel.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.ComponentModel.dll": {}
-        }
-      },
-      "System.ComponentModel.Annotations/4.1.0": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.ComponentModel": "4.0.1",
-          "System.Globalization": "4.0.11",
-          "System.Linq": "4.1.0",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Text.RegularExpressions": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.ComponentModel.Annotations.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.ComponentModel.Annotations.dll": {}
-        }
-      },
-      "System.ComponentModel.EventBasedAsync/4.0.11": {
-        "dependencies": {
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.ComponentModel.EventBasedAsync.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.ComponentModel.EventBasedAsync.dll": {}
-        }
-      },
-      "System.Data.Common/4.1.0": {
-        "compile": {
-          "ref/netstandard1.2/System.Data.Common.dll": {}
-        },
-        "runtime": {
-          "lib/netstandard1.2/System.Data.Common.dll": {}
-        }
-      },
-      "System.Diagnostics.Contracts/4.0.1": {
-        "dependencies": {
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Diagnostics.Contracts.dll": {}
-        }
-      },
-      "System.Diagnostics.Debug/4.0.11": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.win.System.Diagnostics.Debug": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Diagnostics.Debug.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Diagnostics.DiagnosticSource/4.0.0": {
-        "compile": {
-          "lib/netstandard1.3/_._": {}
-        },
-        "runtime": {
-          "lib/netstandard1.3/System.Diagnostics.DiagnosticSource.dll": {}
-        }
-      },
-      "System.Diagnostics.StackTrace/4.0.2": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Diagnostics.StackTrace.dll": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Diagnostics.StackTrace.dll": {}
-        }
-      },
-      "System.Diagnostics.Tools/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Diagnostics.Tools": "4.0.1"
-        },
-        "compile": {
-          "ref/netcore50/System.Diagnostics.Tools.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Diagnostics.Tracing/4.1.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Diagnostics.Tracing": "4.0.20"
-        },
-        "compile": {
-          "ref/netcore50/System.Diagnostics.Tracing.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Dynamic.Runtime/4.0.11": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.Linq": "4.1.0",
-          "System.Linq.Expressions": "4.1.0",
-          "System.ObjectModel": "4.0.12",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Dynamic.Runtime.dll": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Dynamic.Runtime.dll": {}
-        }
-      },
-      "System.Globalization/4.0.11": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Globalization": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Globalization.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Globalization.Calendars/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Globalization": "4.0.11",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Globalization.Calendars": "4.0.1"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Globalization.Calendars.dll": {}
-        }
-      },
-      "System.Globalization.Extensions/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Globalization": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Globalization.Extensions.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netstandard1.3/System.Globalization.Extensions.dll": {}
-        }
-      },
-      "System.IO/4.1.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Text.Encoding": "4.0.11",
-          "System.Threading.Tasks": "4.0.11",
-          "runtime.aot.System.IO": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.IO.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.IO.Compression/4.1.1": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Text.Encoding": "4.0.11",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11",
-          "runtime.native.System.IO.Compression": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.IO.Compression.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netstandard1.3/System.IO.Compression.dll": {}
-        }
-      },
-      "System.IO.Compression.ZipFile/4.0.1": {
-        "dependencies": {
-          "System.Buffers": "4.0.0",
-          "System.IO": "4.1.0",
-          "System.IO.Compression": "4.1.0",
-          "System.IO.FileSystem": "4.0.1",
-          "System.IO.FileSystem.Primitives": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Text.Encoding": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
-        },
-        "runtime": {
-          "lib/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
-        }
-      },
-      "System.IO.FileSystem/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.IO": "4.1.0",
-          "System.IO.FileSystem.Primitives": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Text.Encoding": "4.0.11",
-          "System.Threading.Tasks": "4.0.11",
-          "runtime.win.System.IO.FileSystem": "4.0.1"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.IO.FileSystem.dll": {}
-        }
-      },
-      "System.IO.FileSystem.Primitives/4.0.1": {
-        "dependencies": {
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
-        },
-        "runtime": {
-          "lib/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
-        }
-      },
-      "System.IO.IsolatedStorage/4.0.1": {
-        "dependencies": {
-          "System.IO": "4.1.0",
-          "System.IO.FileSystem": "4.0.1",
-          "System.IO.FileSystem.Primitives": "4.0.1",
-          "System.Linq": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.4/System.IO.IsolatedStorage.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.IO.IsolatedStorage.dll": {}
-        }
-      },
-      "System.IO.UnmanagedMemoryStream/4.0.1": {
-        "dependencies": {
-          "System.IO": "4.1.0",
-          "System.IO.FileSystem.Primitives": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.IO.UnmanagedMemoryStream.dll": {}
-        },
-        "runtime": {
-          "lib/netstandard1.3/System.IO.UnmanagedMemoryStream.dll": {}
-        }
-      },
-      "System.Linq/4.1.0": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Linq.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Linq.dll": {}
-        }
-      },
-      "System.Linq.Expressions/4.1.0": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Linq": "4.1.0",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Emit.ILGeneration": "4.0.1",
-          "System.Reflection.Emit.Lightweight": "4.0.1",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Linq.Expressions.dll": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Linq.Expressions.dll": {}
-        }
-      },
-      "System.Linq.Parallel/4.0.1": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Collections.Concurrent": "4.0.12",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Diagnostics.Tracing": "4.1.0",
-          "System.Linq": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Linq.Parallel.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Linq.Parallel.dll": {}
-        }
-      },
-      "System.Linq.Queryable/4.0.1": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Linq": "4.1.0",
-          "System.Linq.Expressions": "4.1.0",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Linq.Queryable.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Linq.Queryable.dll": {}
-        }
-      },
-      "System.Net.Http/4.1.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Diagnostics.DiagnosticSource": "4.0.0",
-          "System.Diagnostics.Tracing": "4.1.0",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Net.Primitives": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Runtime.WindowsRuntime": "4.0.11",
-          "System.Security.Cryptography.X509Certificates": "4.1.0",
-          "System.Text.Encoding": "4.0.11",
-          "System.Text.Encoding.Extensions": "4.0.11",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Net.Http.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netcore50/System.Net.Http.dll": {}
-        }
-      },
-      "System.Net.Http.Rtc/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Net.Http": "4.1.0",
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Net.Http.Rtc.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netcore50/System.Net.Http.Rtc.dll": {}
-        }
-      },
-      "System.Net.NameResolution/4.0.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Tracing": "4.1.0",
-          "System.Globalization": "4.0.11",
-          "System.Net.Primitives": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Net.NameResolution.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netcore50/System.Net.NameResolution.dll": {}
-        }
-      },
-      "System.Net.NetworkInformation/4.1.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.Win32.Primitives": "4.0.1",
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Tracing": "4.1.0",
-          "System.Globalization": "4.0.11",
-          "System.Net.Primitives": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Runtime.InteropServices.WindowsRuntime": "4.0.1",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Net.NetworkInformation.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netcore50/System.Net.NetworkInformation.dll": {}
-        }
-      },
-      "System.Net.Primitives/4.0.11": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "runtime.win.System.Net.Primitives": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Net.Primitives.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Net.Requests/4.0.11": {
-        "dependencies": {
-          "System.IO": "4.1.0",
-          "System.Net.Primitives": "4.0.11",
-          "System.Net.WebHeaderCollection": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Net.Requests.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netstandard1.3/System.Net.Requests.dll": {}
-        }
-      },
-      "System.Net.Sockets/4.1.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.IO": "4.1.0",
-          "System.Net.Primitives": "4.0.11",
-          "System.Runtime": "4.1.0",
-          "System.Threading.Tasks": "4.0.11",
-          "runtime.win.System.Net.Sockets": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Net.Sockets.dll": {}
-        }
-      },
-      "System.Net.WebHeaderCollection/4.0.1": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
-        },
-        "runtime": {
-          "lib/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
-        }
-      },
-      "System.Net.WebSockets/4.0.0": {
-        "dependencies": {
-          "Microsoft.Win32.Primitives": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Net.WebSockets.dll": {}
-        },
-        "runtime": {
-          "lib/netstandard1.3/System.Net.WebSockets.dll": {}
-        }
-      },
-      "System.Net.WebSockets.Client/4.0.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Diagnostics.Tracing": "4.1.0",
-          "System.Globalization": "4.0.11",
-          "System.Net.Primitives": "4.0.11",
-          "System.Net.WebHeaderCollection": "4.0.1",
-          "System.Net.WebSockets": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.InteropServices.WindowsRuntime": "4.0.1",
-          "System.Runtime.WindowsRuntime": "4.0.11",
-          "System.Security.Cryptography.X509Certificates": "4.1.0",
-          "System.Text.Encoding": "4.0.11",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Net.WebSockets.Client.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netcore50/System.Net.WebSockets.Client.dll": {}
-        }
-      },
-      "System.Numerics.Vectors/4.1.1": {
-        "compile": {
-          "ref/netstandard1.0/System.Numerics.Vectors.dll": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win8+wp8+wpa81/System.Numerics.Vectors.dll": {}
-        }
-      },
-      "System.Numerics.Vectors.WindowsRuntime/4.0.1": {
-        "dependencies": {
-          "System.Numerics.Vectors": "4.1.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.WindowsRuntime": "4.0.11"
-        },
-        "compile": {
-          "lib/uap10.0/System.Numerics.Vectors.WindowsRuntime.dll": {}
-        },
-        "runtime": {
-          "lib/uap10.0/System.Numerics.Vectors.WindowsRuntime.dll": {}
-        }
-      },
-      "System.ObjectModel/4.0.12": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.ObjectModel.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.ObjectModel.dll": {}
-        }
-      },
-      "System.Private.DataContractSerialization/4.1.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Collections": "4.0.11",
-          "System.Collections.Concurrent": "4.0.12",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Linq": "4.1.0",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Serialization.Primitives": "4.1.1",
-          "System.Text.Encoding": "4.0.11",
-          "System.Text.Encoding.Extensions": "4.0.11",
-          "System.Text.RegularExpressions": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XmlDocument": "4.0.1",
-          "System.Xml.XmlSerializer": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Private.DataContractSerialization.dll": {}
-        }
-      },
-      "System.Private.ServiceModel/4.1.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Collections": "4.0.11",
-          "System.Collections.Concurrent": "4.0.12",
-          "System.Collections.NonGeneric": "4.0.1",
-          "System.Collections.Specialized": "4.0.1",
-          "System.ComponentModel.EventBasedAsync": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Diagnostics.Tracing": "4.1.0",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.IO.Compression": "4.1.0",
-          "System.Linq": "4.1.0",
-          "System.Linq.Expressions": "4.1.0",
-          "System.Linq.Queryable": "4.0.1",
-          "System.Net.Http": "4.1.0",
-          "System.Net.Primitives": "4.0.11",
-          "System.Net.WebHeaderCollection": "4.0.1",
-          "System.Net.WebSockets": "4.0.0",
-          "System.Net.WebSockets.Client": "4.0.0",
-          "System.ObjectModel": "4.0.12",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.DispatchProxy": "4.0.1",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Runtime.Serialization.Primitives": "4.1.1",
-          "System.Runtime.Serialization.Xml": "4.1.1",
-          "System.Runtime.WindowsRuntime": "4.0.11",
-          "System.Security.Claims": "4.0.1",
-          "System.Security.Cryptography.Algorithms": "4.2.0",
-          "System.Security.Cryptography.Encoding": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.1.0",
-          "System.Security.Principal": "4.0.1",
-          "System.Text.Encoding": "4.0.11",
-          "System.Text.Encoding.Extensions": "4.0.11",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11",
-          "System.Threading.Timer": "4.0.1",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XmlDocument": "4.0.1",
-          "System.Xml.XmlSerializer": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "runtimes/win7/lib/netcore50/System.Private.ServiceModel.dll": {}
-        }
-      },
-      "System.Private.Uri/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "runtime.win7.System.Private.Uri": "4.0.2"
-        },
-        "compile": {
-          "ref/netstandard/_._": {}
-        }
-      },
-      "System.Reflection/4.1.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.IO": "4.1.0",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Reflection": "4.0.10"
-        },
-        "compile": {
-          "ref/netcore50/System.Reflection.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Reflection.Context/4.0.1": {
-        "dependencies": {
-          "System.Reflection": "4.1.0",
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Reflection.Context.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Reflection.Context.dll": {}
-        }
-      },
-      "System.Reflection.DispatchProxy/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Reflection.DispatchProxy.dll": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {}
-        }
-      },
-      "System.Reflection.Emit/4.0.1": {
-        "dependencies": {
-          "System.IO": "4.1.0",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Emit.ILGeneration": "4.0.1",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard1.1/_._": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Reflection.Emit.dll": {}
-        }
-      },
-      "System.Reflection.Emit.ILGeneration/4.0.1": {
-        "dependencies": {
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard1.0/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/_._": {}
-        }
-      },
-      "System.Reflection.Emit.Lightweight/4.0.1": {
-        "dependencies": {
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Emit.ILGeneration": "4.0.1",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard1.0/_._": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/_._": {}
-        }
-      },
-      "System.Reflection.Extensions/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Reflection": "4.1.0",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Reflection.Extensions": "4.0.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Reflection.Extensions.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Reflection.Metadata/1.3.0": {
-        "dependencies": {
-          "System.Collections.Immutable": "1.2.0"
-        },
-        "compile": {
-          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
-        }
-      },
-      "System.Reflection.Primitives/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Reflection.Primitives": "4.0.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Reflection.Primitives.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Reflection.TypeExtensions/4.1.0": {
-        "dependencies": {
-          "System.Diagnostics.Contracts": "4.0.1",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Linq": "4.1.0",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Reflection.TypeExtensions.dll": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Reflection.TypeExtensions.dll": {}
-        }
-      },
-      "System.Resources.ResourceManager/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Globalization": "4.0.11",
-          "System.Reflection": "4.1.0",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Resources.ResourceManager": "4.0.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Resources.ResourceManager.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Runtime/4.1.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "runtime.aot.System.Runtime": "4.0.20"
-        },
-        "compile": {
-          "ref/netcore50/System.Runtime.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Runtime.Extensions/4.1.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.win.System.Runtime.Extensions": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Runtime.Extensions.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Runtime.Handles/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Runtime.Handles": "4.0.1"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Runtime.Handles.dll": {}
-        }
-      },
-      "System.Runtime.InteropServices/4.1.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "runtime.aot.System.Runtime.InteropServices": "4.0.20"
-        },
-        "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Runtime.InteropServices.WindowsRuntime/4.0.1": {
-        "dependencies": {
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
-        }
-      },
-      "System.Runtime.Numerics/4.0.1": {
-        "dependencies": {
-          "System.Globalization": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Runtime.Numerics.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Runtime.Numerics.dll": {}
-        }
-      },
-      "System.Runtime.Serialization.Json/4.0.2": {
-        "dependencies": {
-          "System.IO": "4.1.0",
-          "System.Private.DataContractSerialization": "4.1.1",
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
-        }
-      },
-      "System.Runtime.Serialization.Primitives/4.1.1": {
-        "dependencies": {
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Primitives.dll": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Runtime.Serialization.Primitives.dll": {}
-        }
-      },
-      "System.Runtime.Serialization.Xml/4.1.1": {
-        "dependencies": {
-          "System.IO": "4.1.0",
-          "System.Private.DataContractSerialization": "4.1.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Serialization.Primitives": "4.1.1",
-          "System.Text.Encoding": "4.0.11",
-          "System.Xml.ReaderWriter": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Runtime.Serialization.Xml.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
-        }
-      },
-      "System.Runtime.WindowsRuntime/4.0.11": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
-        },
-        "runtime": {
-          "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
-        }
-      },
-      "System.Runtime.WindowsRuntime.UI.Xaml/4.0.1": {
-        "dependencies": {
-          "System.Runtime": "4.1.0",
-          "System.Runtime.WindowsRuntime": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
-        },
-        "runtime": {
-          "runtimes/win8/lib/netstandard1.3/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
-        }
-      },
-      "System.Security.Claims/4.0.1": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Security.Principal": "4.0.1"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Security.Claims.dll": {}
-        },
-        "runtime": {
-          "lib/netstandard1.3/System.Security.Claims.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Algorithms/4.2.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.IO": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Security.Cryptography.Encoding": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0",
-          "System.Text.Encoding": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.4/System.Security.Cryptography.Algorithms.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netcore50/System.Security.Cryptography.Algorithms.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Cng/4.2.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.IO": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Security.Cryptography.Algorithms": "4.2.0",
-          "System.Security.Cryptography.Encoding": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0",
-          "System.Text.Encoding": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.4/_._": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netstandard1.4/System.Security.Cryptography.Cng.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Encoding/4.0.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Collections": "4.0.11",
-          "System.Collections.Concurrent": "4.0.12",
-          "System.Linq": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Security.Cryptography.Primitives": "4.0.0",
-          "System.Text.Encoding": "4.0.11",
-          "runtime.native.System.Security.Cryptography": "4.0.0"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Primitives/4.0.0": {
-        "dependencies": {
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
-        },
-        "runtime": {
-          "lib/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
-        }
-      },
-      "System.Security.Cryptography.X509Certificates/4.1.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Collections": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.Globalization.Calendars": "4.0.1",
-          "System.IO": "4.1.0",
-          "System.IO.FileSystem": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Runtime.Numerics": "4.0.1",
-          "System.Security.Cryptography.Algorithms": "4.2.0",
-          "System.Security.Cryptography.Cng": "4.2.0",
-          "System.Security.Cryptography.Encoding": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0",
-          "System.Text.Encoding": "4.0.11",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.4/System.Security.Cryptography.X509Certificates.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netcore50/System.Security.Cryptography.X509Certificates.dll": {}
-        }
-      },
-      "System.Security.Principal/4.0.1": {
-        "dependencies": {
-          "System.Runtime": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Security.Principal.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Security.Principal.dll": {}
-        }
-      },
-      "System.ServiceModel.Duplex/4.0.1": {
-        "dependencies": {
-          "System.Private.ServiceModel": "4.1.0",
-          "System.Runtime": "4.1.0",
-          "System.ServiceModel.Primitives": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.ServiceModel.Duplex.dll": {}
-        }
-      },
-      "System.ServiceModel.Http/4.1.0": {
-        "dependencies": {
-          "System.Net.Primitives": "4.0.11",
-          "System.Net.WebHeaderCollection": "4.0.1",
-          "System.Private.ServiceModel": "4.1.0",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Serialization.Xml": "4.1.1",
-          "System.ServiceModel.Primitives": "4.1.0",
-          "System.Text.Encoding": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.ServiceModel.Http.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.ServiceModel.Http.dll": {}
-        }
-      },
-      "System.ServiceModel.NetTcp/4.1.0": {
-        "dependencies": {
-          "System.Net.Primitives": "4.0.11",
-          "System.Private.ServiceModel": "4.1.0",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Serialization.Xml": "4.1.1",
-          "System.ServiceModel.Primitives": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
-        }
-      },
-      "System.ServiceModel.Primitives/4.1.0": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.ComponentModel.EventBasedAsync": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Net.Primitives": "4.0.11",
-          "System.ObjectModel": "4.0.12",
-          "System.Private.ServiceModel": "4.1.0",
-          "System.Reflection": "4.1.0",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Serialization.Primitives": "4.1.1",
-          "System.Runtime.Serialization.Xml": "4.1.1",
-          "System.Security.Cryptography.X509Certificates": "4.1.0",
-          "System.Security.Principal": "4.0.1",
-          "System.Text.Encoding": "4.0.11",
-          "System.Threading": "4.0.11",
-          "System.Xml.ReaderWriter": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.ServiceModel.Primitives.dll": {}
-        }
-      },
-      "System.ServiceModel.Security/4.0.1": {
-        "dependencies": {
-          "System.Private.ServiceModel": "4.1.0",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Serialization.Xml": "4.1.1",
-          "System.ServiceModel.Primitives": "4.1.0"
-        },
-        "compile": {
-          "ref/netcore50/System.ServiceModel.Security.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.ServiceModel.Security.dll": {}
-        }
-      },
-      "System.Text.Encoding/4.0.11": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Text.Encoding": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Text.Encoding.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Text.Encoding.CodePages/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Collections": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Reflection": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Text.Encoding": "4.0.11",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Text.Encoding.CodePages.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netstandard1.3/System.Text.Encoding.CodePages.dll": {}
-        }
-      },
-      "System.Text.Encoding.Extensions/4.0.11": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Text.Encoding": "4.0.11",
-          "runtime.aot.System.Text.Encoding.Extensions": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Text.Encoding.Extensions.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Text.RegularExpressions/4.1.0": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Text.RegularExpressions.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Text.RegularExpressions.dll": {}
-        }
-      },
-      "System.Threading/4.0.11": {
-        "dependencies": {
-          "System.Runtime": "4.1.0",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Threading.dll": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Threading.dll": {}
-        }
-      },
-      "System.Threading.Overlapped/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Handles": "4.0.1",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.3/System.Threading.Overlapped.dll": {}
-        },
-        "runtime": {
-          "runtimes/win/lib/netcore50/System.Threading.Overlapped.dll": {}
-        }
-      },
-      "System.Threading.Tasks/4.0.11": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Threading.Tasks.dll": {}
-        },
-        "runtime": {
-          "lib/win8/_._": {}
-        }
-      },
-      "System.Threading.Tasks.Dataflow/4.6.0": {
-        "compile": {
-          "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll": {}
-        },
-        "runtime": {
-          "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll": {}
-        }
-      },
-      "System.Threading.Tasks.Extensions/4.0.0": {
-        "compile": {
-          "lib/portable-net45+win8+wp8+wpa81/_._": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Extensions.dll": {}
-        }
-      },
-      "System.Threading.Tasks.Parallel/4.0.1": {
-        "dependencies": {
-          "System.Collections.Concurrent": "4.0.12",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Diagnostics.Tracing": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
-        }
-      },
-      "System.Threading.Timer/4.0.1": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1",
-          "Microsoft.NETCore.Targets": "1.0.1",
-          "System.Runtime": "4.1.0",
-          "runtime.aot.System.Threading.Timer": "4.0.1"
-        },
-        "compile": {
-          "ref/netcore50/System.Threading.Timer.dll": {}
-        },
-        "runtime": {
-          "lib/win81/_._": {}
-        }
-      },
-      "System.Xml.ReaderWriter/4.0.11": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.IO.FileSystem": "4.0.1",
-          "System.IO.FileSystem.Primitives": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Text.Encoding": "4.0.11",
-          "System.Text.Encoding.Extensions": "4.0.11",
-          "System.Text.RegularExpressions": "4.1.0",
-          "System.Threading.Tasks": "4.0.11",
-          "System.Threading.Tasks.Extensions": "4.0.0"
-        },
-        "compile": {
-          "ref/netcore50/System.Xml.ReaderWriter.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Xml.ReaderWriter.dll": {}
-        }
-      },
-      "System.Xml.XDocument/4.0.11": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Diagnostics.Tools": "4.0.1",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Reflection": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Text.Encoding": "4.0.11",
-          "System.Threading": "4.0.11",
-          "System.Xml.ReaderWriter": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/System.Xml.XDocument.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Xml.XDocument.dll": {}
-        }
-      },
-      "System.Xml.XmlDocument/4.0.1": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Text.Encoding": "4.0.11",
-          "System.Threading": "4.0.11",
-          "System.Xml.ReaderWriter": "4.0.11"
-        },
-        "compile": {
-          "ref/netstandard1.3/_._": {}
-        },
-        "runtime": {
-          "lib/netstandard1.3/System.Xml.XmlDocument.dll": {}
-        }
-      },
-      "System.Xml.XmlSerializer/4.0.11": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Linq": "4.1.0",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Emit": "4.0.1",
-          "System.Reflection.Emit.ILGeneration": "4.0.1",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Text.RegularExpressions": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XmlDocument": "4.0.1"
-        },
-        "compile": {
-          "ref/netcore50/System.Xml.XmlSerializer.dll": {}
-        },
-        "runtime": {
-          "runtimes/aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
-        }
-      }
-    },
-    "UAP,Version=v10.0/win10-x64": {
-      "Microsoft.CSharp/4.0.1": {
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Dynamic.Runtime": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.Linq": "4.1.0",
-          "System.Linq.Expressions": "4.1.0",
-          "System.ObjectModel": "4.0.12",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Threading": "4.0.11"
-        },
-        "compile": {
-          "ref/netcore50/Microsoft.CSharp.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/Microsoft.CSharp.dll": {}
-        }
-      },
-      "Microsoft.NETCore/5.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.CSharp": "4.0.1",
           "Microsoft.NETCore.Platforms": "1.0.1",
@@ -6504,11 +4576,10 @@
         }
       },
       "Microsoft.NETCore.Jit/1.0.3": {
-        "dependencies": {
-          "runtime.win7-x64.Microsoft.NETCore.Jit": "1.0.3"
-        }
+        "type": "package"
       },
       "Microsoft.NETCore.Platforms/1.0.1": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.0/_._": {}
         },
@@ -6517,6 +4588,7 @@
         }
       },
       "Microsoft.NETCore.Portable.Compatibility/1.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
         },
@@ -6536,28 +4608,31 @@
           "ref/netcore50/mscorlib.dll": {}
         },
         "runtime": {
-          "lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
-          "lib/netcore50/System.Core.dll": {},
-          "lib/netcore50/System.Net.dll": {},
-          "lib/netcore50/System.Numerics.dll": {},
-          "lib/netcore50/System.Runtime.Serialization.dll": {},
-          "lib/netcore50/System.ServiceModel.Web.dll": {},
-          "lib/netcore50/System.ServiceModel.dll": {},
-          "lib/netcore50/System.Windows.dll": {},
-          "lib/netcore50/System.Xml.Linq.dll": {},
-          "lib/netcore50/System.Xml.Serialization.dll": {},
-          "lib/netcore50/System.Xml.dll": {},
-          "lib/netcore50/System.dll": {}
+          "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
+          "runtimes/aot/lib/netcore50/System.Core.dll": {},
+          "runtimes/aot/lib/netcore50/System.Net.dll": {},
+          "runtimes/aot/lib/netcore50/System.Numerics.dll": {},
+          "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {},
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {},
+          "runtimes/aot/lib/netcore50/System.Windows.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {},
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {},
+          "runtimes/aot/lib/netcore50/System.dll": {},
+          "runtimes/aot/lib/netcore50/mscorlib.dll": {}
         }
       },
       "Microsoft.NETCore.Runtime.CoreCLR/1.0.3": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Jit": "1.0.3",
           "Microsoft.NETCore.Windows.ApiSets": "1.0.1",
-          "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
+          "runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
         }
       },
       "Microsoft.NETCore.Targets/1.0.2": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.0/_._": {}
         },
@@ -6566,6 +4641,7 @@
         }
       },
       "Microsoft.NETCore.UniversalWindowsPlatform/5.2.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore": "5.0.2",
           "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
@@ -6601,8 +4677,11 @@
           "System.Xml.XmlSerializer": "4.0.11"
         }
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {},
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {
+        "type": "package"
+      },
       "Microsoft.VisualBasic/10.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -6629,6 +4708,7 @@
         }
       },
       "Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -6640,12 +4720,14 @@
         }
       },
       "MvvmCross/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Binding": "4.3.0",
           "MvvmCross.Core": "4.3.0"
         }
       },
       "MvvmCross.Binding/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Core": "4.3.0"
         },
@@ -6659,6 +4741,7 @@
         }
       },
       "MvvmCross.Core/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Platform": "4.3.0"
         },
@@ -6672,6 +4755,7 @@
         }
       },
       "MvvmCross.Platform/4.3.0": {
+        "type": "package",
         "compile": {
           "lib/win81/MvvmCross.Platform.WindowsCommon.dll": {},
           "lib/win81/MvvmCross.Platform.dll": {}
@@ -6681,90 +4765,143 @@
           "lib/win81/MvvmCross.Platform.dll": {}
         }
       },
-      "runtime.any.System.Collections/4.0.11": {
+      "runtime.aot.System.Collections/4.0.10": {
+        "type": "package",
         "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Collections.dll": {}
+        }
+      },
+      "runtime.aot.System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "runtime.aot.System.Diagnostics.Tracing/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "runtime.aot.System.Globalization/4.0.11": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Globalization.dll": {}
+        }
+      },
+      "runtime.aot.System.Globalization.Calendars/4.0.1": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "runtime.aot.System.IO/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.IO.dll": {}
+        }
+      },
+      "runtime.aot.System.Reflection/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Reflection.dll": {}
+        }
+      },
+      "runtime.aot.System.Reflection.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "runtime.aot.System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "runtime.aot.System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11",
+          "System.Reflection": "4.1.0",
           "System.Runtime": "4.1.0"
         },
         "compile": {
           "ref/netstandard/_._": {}
         },
         "runtime": {
-          "lib/netcore50/System.Collections.dll": {}
+          "runtimes/aot/lib/netcore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "runtime.any.System.Diagnostics.Tools/4.0.1": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Diagnostics.Tools.dll": {}
-        }
-      },
-      "runtime.any.System.Diagnostics.Tracing/4.1.0": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Diagnostics.Tracing.dll": {}
-        }
-      },
-      "runtime.any.System.Globalization/4.0.11": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Globalization.dll": {}
-        }
-      },
-      "runtime.any.System.Globalization.Calendars/4.0.1": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Globalization.Calendars.dll": {}
-        }
-      },
-      "runtime.any.System.IO/4.1.0": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.IO.dll": {}
-        }
-      },
-      "runtime.any.System.Reflection/4.1.0": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Reflection.dll": {}
-        }
-      },
-      "runtime.any.System.Reflection.Extensions/4.0.1": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Reflection.Extensions.dll": {}
-        }
-      },
-      "runtime.any.System.Reflection.Primitives/4.0.1": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Reflection.Primitives.dll": {}
-        }
-      },
-      "runtime.any.System.Resources.ResourceManager/4.0.1": {
-        "compile": {
-          "ref/netstandard/_._": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Resources.ResourceManager.dll": {}
-        }
-      },
-      "runtime.any.System.Runtime/4.1.0": {
+      "runtime.aot.System.Runtime/4.0.20": {
+        "type": "package",
         "dependencies": {
           "System.Private.Uri": "4.0.1"
         },
@@ -6772,62 +4909,72 @@
           "ref/netstandard/_._": {}
         },
         "runtime": {
-          "lib/netcore50/System.Runtime.dll": {}
+          "runtimes/aot/lib/netcore50/System.Runtime.dll": {}
         }
       },
-      "runtime.any.System.Runtime.Handles/4.0.1": {
+      "runtime.aot.System.Runtime.Handles/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
         "runtime": {
-          "lib/netstandard1.3/System.Runtime.Handles.dll": {}
+          "runtimes/aot/lib/netcore50/System.Runtime.Handles.dll": {}
         }
       },
-      "runtime.any.System.Runtime.InteropServices/4.1.0": {
+      "runtime.aot.System.Runtime.InteropServices/4.0.20": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
         "runtime": {
-          "lib/netcore50/System.Runtime.InteropServices.dll": {}
+          "runtimes/aot/lib/netcore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "runtime.any.System.Text.Encoding/4.0.11": {
+      "runtime.aot.System.Text.Encoding/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
         "runtime": {
-          "lib/netcore50/System.Text.Encoding.dll": {}
+          "runtimes/aot/lib/netcore50/System.Text.Encoding.dll": {}
         }
       },
-      "runtime.any.System.Text.Encoding.Extensions/4.0.11": {
+      "runtime.aot.System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
         "runtime": {
-          "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
+          "runtimes/aot/lib/netcore50/System.Text.Encoding.Extensions.dll": {}
         }
       },
-      "runtime.any.System.Threading.Tasks/4.0.11": {
+      "runtime.aot.System.Threading.Tasks/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
         "runtime": {
-          "lib/netcore50/System.Threading.Tasks.dll": {}
+          "runtimes/aot/lib/netcore50/System.Threading.Tasks.dll": {}
         }
       },
-      "runtime.any.System.Threading.Timer/4.0.1": {
+      "runtime.aot.System.Threading.Timer/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        },
         "compile": {
           "ref/netstandard/_._": {}
         },
         "runtime": {
-          "lib/netcore50/System.Threading.Timer.dll": {}
+          "runtimes/aot/lib/netcore50/System.Threading.Timer.dll": {}
         }
       },
       "runtime.native.System.IO.Compression/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
-          "runtime.win7-x64.runtime.native.System.IO.Compression": "4.0.1"
+          "runtime.win10-arm-aot.runtime.native.System.IO.Compression": "4.0.1"
         },
         "compile": {
           "lib/netstandard1.0/_._": {}
@@ -6837,6 +4984,7 @@
         }
       },
       "runtime.native.System.Security.Cryptography/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1"
@@ -6849,6 +4997,7 @@
         }
       },
       "runtime.win.Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Runtime.InteropServices": "4.1.0"
@@ -6861,14 +5010,16 @@
         }
       },
       "runtime.win.System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
         "runtime": {
-          "runtimes/win/lib/netcore50/System.Diagnostics.Debug.dll": {}
+          "runtimes/aot/lib/netcore50/System.Diagnostics.Debug.dll": {}
         }
       },
       "runtime.win.System.IO.FileSystem/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -6894,6 +5045,7 @@
         }
       },
       "runtime.win.System.Net.Primitives/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.1",
           "System.Collections": "4.0.11",
@@ -6914,6 +5066,7 @@
         }
       },
       "runtime.win.System.Net.Sockets/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -6941,6 +5094,2300 @@
         }
       },
       "runtime.win.System.Runtime.Extensions/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.1"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "runtime.win10-arm-aot.runtime.native.System.IO.Compression/4.0.1": {
+        "type": "package",
+        "compile": {
+          "runtimes/win10-arm-aot/lib/netcore50/_._": {}
+        },
+        "runtime": {
+          "runtimes/win10-arm-aot/lib/netcore50/clrcompression.dll": {}
+        }
+      },
+      "runtime.win7.System.Private.Uri/4.0.2": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Private.Uri.dll": {}
+        }
+      },
+      "runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR/1.0.2": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard1.0/_._": {}
+        },
+        "runtime": {
+          "runtimes/win8-arm-aot/lib/netstandard1.0/_._": {}
+        },
+        "native": {
+          "runtimes/win8-arm-aot/native/_._": {}
+        }
+      },
+      "System.AppContext/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.AppContext.dll": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.AppContext.dll": {}
+        }
+      },
+      "System.Buffers/4.0.0": {
+        "type": "package",
+        "compile": {
+          "lib/netstandard1.1/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Buffers.dll": {}
+        }
+      },
+      "System.Collections/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Collections": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Collections.Concurrent/4.0.12": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Collections.Concurrent.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.2.0": {
+        "type": "package",
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Collections.NonGeneric/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Globalization.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.ComponentModel/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.ComponentModel.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.ComponentModel.dll": {}
+        }
+      },
+      "System.ComponentModel.Annotations/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.ComponentModel": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.ComponentModel.Annotations.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.ComponentModel.Annotations.dll": {}
+        }
+      },
+      "System.ComponentModel.EventBasedAsync/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.ComponentModel.EventBasedAsync.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.ComponentModel.EventBasedAsync.dll": {}
+        }
+      },
+      "System.Data.Common/4.1.0": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard1.2/System.Data.Common.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.2/System.Data.Common.dll": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Diagnostics.Contracts.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.win.System.Diagnostics.Debug": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Diagnostics.DiagnosticSource/4.0.0": {
+        "type": "package",
+        "compile": {
+          "lib/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Diagnostics.DiagnosticSource.dll": {}
+        }
+      },
+      "System.Diagnostics.StackTrace/4.0.2": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Diagnostics.StackTrace.dll": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Diagnostics.StackTrace.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Diagnostics.Tools": "4.0.1"
+        },
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Diagnostics.Tracing": "4.0.20"
+        },
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Tracing.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Dynamic.Runtime/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Dynamic.Runtime.dll": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Dynamic.Runtime.dll": {}
+        }
+      },
+      "System.Globalization/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Globalization": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Globalization.Calendars": "4.0.1"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.Extensions.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.3/System.Globalization.Extensions.dll": {}
+        }
+      },
+      "System.IO/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "runtime.aot.System.IO": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.IO.Compression/4.1.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "runtime.native.System.IO.Compression": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.IO.Compression.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.3/System.IO.Compression.dll": {}
+        }
+      },
+      "System.IO.Compression.ZipFile/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Buffers": "4.0.0",
+          "System.IO": "4.1.0",
+          "System.IO.Compression": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "runtime.win.System.IO.FileSystem": "4.0.1"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.IO.IsolatedStorage/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.IO.IsolatedStorage.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.IO.IsolatedStorage.dll": {}
+        }
+      },
+      "System.IO.UnmanagedMemoryStream/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.UnmanagedMemoryStream.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.UnmanagedMemoryStream.dll": {}
+        }
+      },
+      "System.Linq/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Linq.dll": {}
+        }
+      },
+      "System.Linq.Expressions/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Emit.Lightweight": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Linq.Expressions.dll": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Linq.Expressions.dll": {}
+        }
+      },
+      "System.Linq.Parallel/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Linq.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Linq.Parallel.dll": {}
+        }
+      },
+      "System.Linq.Queryable/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Linq.Queryable.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Linq.Queryable.dll": {}
+        }
+      },
+      "System.Net.Http/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.DiagnosticSource": "4.0.0",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.WindowsRuntime": "4.0.11",
+          "System.Security.Cryptography.X509Certificates": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Net.Http.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netcore50/System.Net.Http.dll": {}
+        }
+      },
+      "System.Net.Http.Rtc/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Net.Http": "4.1.0",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Net.Http.Rtc.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netcore50/System.Net.Http.Rtc.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Net.Primitives": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.NameResolution.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netcore50/System.Net.NameResolution.dll": {}
+        }
+      },
+      "System.Net.NetworkInformation/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Net.Primitives": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.1",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Net.NetworkInformation.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netcore50/System.Net.NetworkInformation.dll": {}
+        }
+      },
+      "System.Net.Primitives/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "runtime.win.System.Net.Primitives": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Net.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Net.Requests/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Net.WebHeaderCollection": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Net.Requests.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.3/System.Net.Requests.dll": {}
+        }
+      },
+      "System.Net.Sockets/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "runtime.win.System.Net.Sockets": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Sockets.dll": {}
+        }
+      },
+      "System.Net.WebHeaderCollection/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Net.Primitives": "4.0.11",
+          "System.Net.WebHeaderCollection": "4.0.1",
+          "System.Net.WebSockets": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.1",
+          "System.Runtime.WindowsRuntime": "4.0.11",
+          "System.Security.Cryptography.X509Certificates": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netcore50/System.Net.WebSockets.Client.dll": {}
+        }
+      },
+      "System.Numerics.Vectors/4.1.1": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard1.0/System.Numerics.Vectors.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Numerics.Vectors.dll": {}
+        }
+      },
+      "System.Numerics.Vectors.WindowsRuntime/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Numerics.Vectors": "4.1.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.WindowsRuntime": "4.0.11"
+        },
+        "compile": {
+          "lib/uap10.0/System.Numerics.Vectors.WindowsRuntime.dll": {}
+        },
+        "runtime": {
+          "lib/uap10.0/System.Numerics.Vectors.WindowsRuntime.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.12": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Private.DataContractSerialization/4.1.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XmlDocument": "4.0.1",
+          "System.Xml.XmlSerializer": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Private.DataContractSerialization.dll": {}
+        }
+      },
+      "System.Private.ServiceModel/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Collections.NonGeneric": "4.0.1",
+          "System.Collections.Specialized": "4.0.1",
+          "System.ComponentModel.EventBasedAsync": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.Compression": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Linq.Queryable": "4.0.1",
+          "System.Net.Http": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Net.WebHeaderCollection": "4.0.1",
+          "System.Net.WebSockets": "4.0.0",
+          "System.Net.WebSockets.Client": "4.0.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.DispatchProxy": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Runtime.Serialization.Xml": "4.1.1",
+          "System.Runtime.WindowsRuntime": "4.0.11",
+          "System.Security.Claims": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.1.0",
+          "System.Security.Principal": "4.0.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Timer": "4.0.1",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XmlDocument": "4.0.1",
+          "System.Xml.XmlSerializer": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netcore50/System.Private.ServiceModel.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "runtime.win7.System.Private.Uri": "4.0.2"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        }
+      },
+      "System.Reflection/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Reflection": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Reflection.Context/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Context.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Context.dll": {}
+        }
+      },
+      "System.Reflection.DispatchProxy/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Reflection.DispatchProxy.dll": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.1/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.0/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/_._": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.0/_._": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/_._": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Reflection.Extensions": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Reflection.Metadata/1.3.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Immutable": "1.2.0"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Reflection.Primitives": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Contracts": "4.0.1",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Resources.ResourceManager": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Runtime/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "runtime.aot.System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Runtime.Extensions/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.win.System.Runtime.Extensions": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Runtime.Handles": "4.0.1"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "runtime.aot.System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Runtime.InteropServices.WindowsRuntime/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+        }
+      },
+      "System.Runtime.Numerics/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.Numerics.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.Numerics.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Json/4.0.2": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Private.DataContractSerialization": "4.1.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.Serialization.Json.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Primitives/4.1.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.Serialization.Primitives.dll": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Runtime.Serialization.Primitives.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Xml/4.1.1": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Private.DataContractSerialization": "4.1.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.Serialization.Xml.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
+        }
+      },
+      "System.Runtime.WindowsRuntime/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.WindowsRuntime.dll": {}
+        },
+        "runtime": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
+        }
+      },
+      "System.Runtime.WindowsRuntime.UI.Xaml/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0",
+          "System.Runtime.WindowsRuntime": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+        },
+        "runtime": {
+          "runtimes/win8/lib/netstandard1.3/System.Runtime.WindowsRuntime.UI.Xaml.dll": {}
+        }
+      },
+      "System.Security.Claims/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Security.Principal": "4.0.1"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Claims.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Security.Claims.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Algorithms/4.2.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.Algorithms.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netcore50/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Cng/4.2.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.4/_._": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.4/System.Security.Cryptography.Cng.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Globalization.Calendars": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Cng": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.X509Certificates.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netcore50/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.Security.Principal/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Security.Principal.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Security.Principal.dll": {}
+        }
+      },
+      "System.ServiceModel.Duplex/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.ServiceModel": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.ServiceModel.Primitives": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.ServiceModel.Duplex.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.ServiceModel.Duplex.dll": {}
+        }
+      },
+      "System.ServiceModel.Http/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Net.Primitives": "4.0.11",
+          "System.Net.WebHeaderCollection": "4.0.1",
+          "System.Private.ServiceModel": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Serialization.Xml": "4.1.1",
+          "System.ServiceModel.Primitives": "4.1.0",
+          "System.Text.Encoding": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.ServiceModel.Http.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.ServiceModel.Http.dll": {}
+        }
+      },
+      "System.ServiceModel.NetTcp/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Net.Primitives": "4.0.11",
+          "System.Private.ServiceModel": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Serialization.Xml": "4.1.1",
+          "System.ServiceModel.Primitives": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.ServiceModel.NetTcp.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.ServiceModel.NetTcp.dll": {}
+        }
+      },
+      "System.ServiceModel.Primitives/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.ComponentModel.EventBasedAsync": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.ObjectModel": "4.0.12",
+          "System.Private.ServiceModel": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Runtime.Serialization.Xml": "4.1.1",
+          "System.Security.Cryptography.X509Certificates": "4.1.0",
+          "System.Security.Principal": "4.0.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.ServiceModel.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.ServiceModel.Primitives.dll": {}
+        }
+      },
+      "System.ServiceModel.Security/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.ServiceModel": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Serialization.Xml": "4.1.1",
+          "System.ServiceModel.Primitives": "4.1.0"
+        },
+        "compile": {
+          "ref/netcore50/System.ServiceModel.Security.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.ServiceModel.Security.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Text.Encoding": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Text.Encoding.CodePages/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.CodePages.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.3/System.Text.Encoding.CodePages.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.aot.System.Text.Encoding.Extensions": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Text.RegularExpressions/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Text.RegularExpressions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Text.RegularExpressions.dll": {}
+        }
+      },
+      "System.Threading/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Threading.dll": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Overlapped/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Overlapped.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netcore50/System.Threading.Overlapped.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Threading.Tasks.Dataflow/4.6.0": {
+        "type": "package",
+        "compile": {
+          "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Extensions/4.0.0": {
+        "type": "package",
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/_._": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Extensions.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Parallel/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Threading.Tasks.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Threading.Tasks.Parallel.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.aot.System.Threading.Timer": "4.0.1"
+        },
+        "compile": {
+          "ref/netcore50/System.Threading.Timer.dll": {}
+        },
+        "runtime": {
+          "lib/win81/_._": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Xml.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Xml.ReaderWriter.dll": {}
+        }
+      },
+      "System.Xml.XDocument/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/System.Xml.XDocument.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Xml.XDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlDocument/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Xml.XmlDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlSerializer/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XmlDocument": "4.0.1"
+        },
+        "compile": {
+          "ref/netcore50/System.Xml.XmlSerializer.dll": {}
+        },
+        "runtime": {
+          "runtimes/aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
+        }
+      },
+      "Metropolis.UI.MVVM.Core/1.0.0": {
+        "type": "project"
+      }
+    },
+    "UAP,Version=v10.0/win10-x64": {
+      "Microsoft.CSharp/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/Microsoft.CSharp.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/Microsoft.CSharp.dll": {}
+        }
+      },
+      "Microsoft.NETCore/5.0.2": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.VisualBasic": "10.0.1",
+          "System.AppContext": "4.1.0",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Collections.Immutable": "1.2.0",
+          "System.ComponentModel": "4.0.1",
+          "System.ComponentModel.Annotations": "4.1.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Globalization.Calendars": "4.0.1",
+          "System.Globalization.Extensions": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.Compression": "4.1.1",
+          "System.IO.Compression.ZipFile": "4.0.1",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.IO.UnmanagedMemoryStream": "4.0.1",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Linq.Parallel": "4.0.1",
+          "System.Linq.Queryable": "4.0.1",
+          "System.Net.Http": "4.1.0",
+          "System.Net.NetworkInformation": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Numerics.Vectors": "4.1.1",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.DispatchProxy": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Metadata": "1.3.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Claims": "4.0.1",
+          "System.Security.Principal": "4.0.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Dataflow": "4.6.0",
+          "System.Threading.Tasks.Parallel": "4.0.1",
+          "System.Threading.Timer": "4.0.1",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.Jit/1.0.3": {
+        "type": "package",
+        "dependencies": {
+          "runtime.win7-x64.Microsoft.NETCore.Jit": "1.0.3"
+        }
+      },
+      "Microsoft.NETCore.Platforms/1.0.1": {
+        "type": "package",
+        "compile": {
+          "lib/netstandard1.0/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/_._": {}
+        }
+      },
+      "Microsoft.NETCore.Portable.Compatibility/1.0.2": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
+        },
+        "compile": {
+          "ref/netcore50/System.ComponentModel.DataAnnotations.dll": {},
+          "ref/netcore50/System.Core.dll": {},
+          "ref/netcore50/System.Net.dll": {},
+          "ref/netcore50/System.Numerics.dll": {},
+          "ref/netcore50/System.Runtime.Serialization.dll": {},
+          "ref/netcore50/System.ServiceModel.Web.dll": {},
+          "ref/netcore50/System.ServiceModel.dll": {},
+          "ref/netcore50/System.Windows.dll": {},
+          "ref/netcore50/System.Xml.Linq.dll": {},
+          "ref/netcore50/System.Xml.Serialization.dll": {},
+          "ref/netcore50/System.Xml.dll": {},
+          "ref/netcore50/System.dll": {},
+          "ref/netcore50/mscorlib.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.ComponentModel.DataAnnotations.dll": {},
+          "lib/netcore50/System.Core.dll": {},
+          "lib/netcore50/System.Net.dll": {},
+          "lib/netcore50/System.Numerics.dll": {},
+          "lib/netcore50/System.Runtime.Serialization.dll": {},
+          "lib/netcore50/System.ServiceModel.Web.dll": {},
+          "lib/netcore50/System.ServiceModel.dll": {},
+          "lib/netcore50/System.Windows.dll": {},
+          "lib/netcore50/System.Xml.Linq.dll": {},
+          "lib/netcore50/System.Xml.Serialization.dll": {},
+          "lib/netcore50/System.Xml.dll": {},
+          "lib/netcore50/System.dll": {}
+        }
+      },
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.3": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Jit": "1.0.3",
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1",
+          "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
+        }
+      },
+      "Microsoft.NETCore.Targets/1.0.2": {
+        "type": "package",
+        "compile": {
+          "lib/netstandard1.0/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/_._": {}
+        }
+      },
+      "Microsoft.NETCore.UniversalWindowsPlatform/5.2.2": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore": "5.0.2",
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.3",
+          "Microsoft.NETCore.Targets": "1.0.2",
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.ComponentModel.EventBasedAsync": "4.0.11",
+          "System.Data.Common": "4.1.0",
+          "System.Diagnostics.Contracts": "4.0.1",
+          "System.Diagnostics.StackTrace": "4.0.2",
+          "System.IO.IsolatedStorage": "4.0.1",
+          "System.Net.Http.Rtc": "4.0.1",
+          "System.Net.NameResolution": "4.0.0",
+          "System.Net.Requests": "4.0.11",
+          "System.Net.Sockets": "4.1.0",
+          "System.Net.WebHeaderCollection": "4.0.1",
+          "System.Net.WebSockets": "4.0.0",
+          "System.Net.WebSockets.Client": "4.0.0",
+          "System.Numerics.Vectors.WindowsRuntime": "4.0.1",
+          "System.Reflection.Context": "4.0.1",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.1",
+          "System.Runtime.Serialization.Json": "4.0.2",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Runtime.Serialization.Xml": "4.1.1",
+          "System.Runtime.WindowsRuntime": "4.0.11",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.1",
+          "System.ServiceModel.Duplex": "4.0.1",
+          "System.ServiceModel.Http": "4.1.0",
+          "System.ServiceModel.NetTcp": "4.1.0",
+          "System.ServiceModel.Primitives": "4.1.0",
+          "System.ServiceModel.Security": "4.0.1",
+          "System.Text.Encoding.CodePages": "4.0.1",
+          "System.Xml.XmlSerializer": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {
+        "type": "package"
+      },
+      "Microsoft.VisualBasic/10.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netcore50/Microsoft.VisualBasic.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/Microsoft.VisualBasic.dll": {}
+        }
+      },
+      "Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.win.Microsoft.Win32.Primitives": "4.0.1"
+        },
+        "compile": {
+          "ref/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "MvvmCross/4.3.0": {
+        "type": "package",
+        "dependencies": {
+          "MvvmCross.Binding": "4.3.0",
+          "MvvmCross.Core": "4.3.0"
+        }
+      },
+      "MvvmCross.Binding/4.3.0": {
+        "type": "package",
+        "dependencies": {
+          "MvvmCross.Core": "4.3.0"
+        },
+        "compile": {
+          "lib/win81/MvvmCross.Binding.dll": {},
+          "lib/win81/MvvmCross.Localization.dll": {}
+        },
+        "runtime": {
+          "lib/win81/MvvmCross.Binding.dll": {},
+          "lib/win81/MvvmCross.Localization.dll": {}
+        }
+      },
+      "MvvmCross.Core/4.3.0": {
+        "type": "package",
+        "dependencies": {
+          "MvvmCross.Platform": "4.3.0"
+        },
+        "compile": {
+          "lib/uap/MvvmCross.Core.dll": {},
+          "lib/uap/MvvmCross.WindowsUWP.dll": {}
+        },
+        "runtime": {
+          "lib/uap/MvvmCross.Core.dll": {},
+          "lib/uap/MvvmCross.WindowsUWP.dll": {}
+        }
+      },
+      "MvvmCross.Platform/4.3.0": {
+        "type": "package",
+        "compile": {
+          "lib/win81/MvvmCross.Platform.WindowsCommon.dll": {},
+          "lib/win81/MvvmCross.Platform.dll": {}
+        },
+        "runtime": {
+          "lib/win81/MvvmCross.Platform.WindowsCommon.dll": {},
+          "lib/win81/MvvmCross.Platform.dll": {}
+        }
+      },
+      "runtime.any.System.Collections/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Collections.dll": {}
+        }
+      },
+      "runtime.any.System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "runtime.any.System.Diagnostics.Tracing/4.1.0": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "runtime.any.System.Globalization/4.0.11": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Globalization.dll": {}
+        }
+      },
+      "runtime.any.System.Globalization.Calendars/4.0.1": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "runtime.any.System.IO/4.1.0": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.IO.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection/4.1.0": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.Extensions/4.0.1": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.Primitives/4.0.1": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "runtime.any.System.Resources.ResourceManager/4.0.1": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.1"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime.Handles/4.0.1": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.Handles.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime.InteropServices/4.1.0": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "runtime.any.System.Text.Encoding/4.0.11": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "runtime.any.System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "runtime.any.System.Threading.Tasks/4.0.11": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Threading.Tasks.dll": {}
+        }
+      },
+      "runtime.any.System.Threading.Timer/4.0.1": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Threading.Timer.dll": {}
+        }
+      },
+      "runtime.native.System.IO.Compression/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "runtime.win7-x64.runtime.native.System.IO.Compression": "4.0.1"
+        },
+        "compile": {
+          "lib/netstandard1.0/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/_._": {}
+        }
+      },
+      "runtime.native.System.Security.Cryptography/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
+        },
+        "compile": {
+          "lib/netstandard1.0/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/_._": {}
+        }
+      },
+      "runtime.win.Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "runtime.win.System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netcore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "runtime.win.System.IO.FileSystem/4.0.1": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.WindowsRuntime": "4.0.11",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Threading.Overlapped": "4.0.1",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netcore50/System.IO.FileSystem.dll": {}
+        }
+      },
+      "runtime.win.System.Net.Primitives/4.0.11": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netcore50/System.Net.Primitives.dll": {}
+        }
+      },
+      "runtime.win.System.Net.Sockets/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Net.NameResolution": "4.0.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Overlapped": "4.0.1",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netcore50/System.Net.Sockets.dll": {}
+        }
+      },
+      "runtime.win.System.Runtime.Extensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Private.Uri": "4.0.1"
         },
@@ -6952,11 +7399,13 @@
         }
       },
       "runtime.win7-x64.Microsoft.NETCore.Jit/1.0.3": {
+        "type": "package",
         "native": {
           "runtimes/win7-x64/native/clrjit.dll": {}
         }
       },
       "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.2": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.0/_._": {}
         },
@@ -6978,11 +7427,13 @@
         }
       },
       "runtime.win7-x64.runtime.native.System.IO.Compression/4.0.1": {
+        "type": "package",
         "native": {
           "runtimes/win7-x64/native/clrcompression.dll": {}
         }
       },
       "runtime.win7.System.Private.Uri/4.0.2": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -6991,6 +7442,7 @@
         }
       },
       "System.AppContext/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -7005,6 +7457,7 @@
         }
       },
       "System.Buffers/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.1/_._": {}
         },
@@ -7013,6 +7466,7 @@
         }
       },
       "System.Collections/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7027,6 +7481,7 @@
         }
       },
       "System.Collections.Concurrent/4.0.12": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -7046,6 +7501,7 @@
         }
       },
       "System.Collections.Immutable/1.2.0": {
+        "type": "package",
         "compile": {
           "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
         },
@@ -7054,6 +7510,7 @@
         }
       },
       "System.Collections.NonGeneric/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -7070,6 +7527,7 @@
         }
       },
       "System.Collections.Specialized/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.1",
           "System.Globalization": "4.0.11",
@@ -7087,6 +7545,7 @@
         }
       },
       "System.ComponentModel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -7098,6 +7557,7 @@
         }
       },
       "System.ComponentModel.Annotations/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.ComponentModel": "4.0.1",
@@ -7119,6 +7579,7 @@
         }
       },
       "System.ComponentModel.EventBasedAsync/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.1",
           "System.Runtime": "4.1.0",
@@ -7133,6 +7594,7 @@
         }
       },
       "System.Data.Common/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.2/System.Data.Common.dll": {}
         },
@@ -7141,6 +7603,7 @@
         }
       },
       "System.Diagnostics.Contracts/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -7152,6 +7615,7 @@
         }
       },
       "System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7166,6 +7630,7 @@
         }
       },
       "System.Diagnostics.DiagnosticSource/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.3/_._": {}
         },
@@ -7174,6 +7639,7 @@
         }
       },
       "System.Diagnostics.StackTrace/4.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1"
         },
@@ -7185,6 +7651,7 @@
         }
       },
       "System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7199,6 +7666,7 @@
         }
       },
       "System.Diagnostics.Tracing/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7213,6 +7681,7 @@
         }
       },
       "System.Dynamic.Runtime/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -7235,6 +7704,7 @@
         }
       },
       "System.Globalization/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7249,6 +7719,7 @@
         }
       },
       "System.Globalization.Calendars/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7261,6 +7732,7 @@
         }
       },
       "System.Globalization.Extensions/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Globalization": "4.0.11",
@@ -7277,6 +7749,7 @@
         }
       },
       "System.IO/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7293,6 +7766,7 @@
         }
       },
       "System.IO.Compression/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -7315,6 +7789,7 @@
         }
       },
       "System.IO.Compression.ZipFile/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Buffers": "4.0.0",
           "System.IO": "4.1.0",
@@ -7334,6 +7809,7 @@
         }
       },
       "System.IO.FileSystem/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7350,6 +7826,7 @@
         }
       },
       "System.IO.FileSystem.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -7361,6 +7838,7 @@
         }
       },
       "System.IO.IsolatedStorage/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.IO.FileSystem": "4.0.1",
@@ -7380,6 +7858,7 @@
         }
       },
       "System.IO.UnmanagedMemoryStream/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.IO.FileSystem.Primitives": "4.0.1",
@@ -7397,6 +7876,7 @@
         }
       },
       "System.Linq/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -7412,6 +7892,7 @@
         }
       },
       "System.Linq.Expressions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -7437,6 +7918,7 @@
         }
       },
       "System.Linq.Parallel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Collections.Concurrent": "4.0.12",
@@ -7457,6 +7939,7 @@
         }
       },
       "System.Linq.Queryable/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -7475,6 +7958,7 @@
         }
       },
       "System.Net.Http/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -7503,6 +7987,7 @@
         }
       },
       "System.Net.Http.Rtc/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Net.Http": "4.1.0",
@@ -7516,6 +8001,7 @@
         }
       },
       "System.Net.NameResolution/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -7538,6 +8024,7 @@
         }
       },
       "System.Net.NetworkInformation/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.Win32.Primitives": "4.0.1",
@@ -7561,6 +8048,7 @@
         }
       },
       "System.Net.Primitives/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7576,6 +8064,7 @@
         }
       },
       "System.Net.Requests/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Net.Primitives": "4.0.11",
@@ -7591,6 +8080,7 @@
         }
       },
       "System.Net.Sockets/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7605,6 +8095,7 @@
         }
       },
       "System.Net.WebHeaderCollection/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -7619,6 +8110,7 @@
         }
       },
       "System.Net.WebSockets/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.1",
           "System.Resources.ResourceManager": "4.0.1",
@@ -7633,6 +8125,7 @@
         }
       },
       "System.Net.WebSockets.Client/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -7660,6 +8153,7 @@
         }
       },
       "System.Numerics.Vectors/4.1.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.0/System.Numerics.Vectors.dll": {}
         },
@@ -7668,6 +8162,7 @@
         }
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Numerics.Vectors": "4.1.1",
           "System.Runtime": "4.1.0",
@@ -7681,6 +8176,7 @@
         }
       },
       "System.ObjectModel/4.0.12": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -7696,6 +8192,7 @@
         }
       },
       "System.Private.DataContractSerialization/4.1.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -7729,6 +8226,7 @@
         }
       },
       "System.Private.ServiceModel/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -7785,6 +8283,7 @@
         }
       },
       "System.Private.Uri/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7795,6 +8294,7 @@
         }
       },
       "System.Reflection/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7811,6 +8311,7 @@
         }
       },
       "System.Reflection.Context/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Runtime": "4.1.0"
@@ -7823,6 +8324,7 @@
         }
       },
       "System.Reflection.DispatchProxy/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Runtime": "4.1.0"
@@ -7835,6 +8337,7 @@
         }
       },
       "System.Reflection.Emit/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Reflection": "4.1.0",
@@ -7850,6 +8353,7 @@
         }
       },
       "System.Reflection.Emit.ILGeneration/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Reflection.Primitives": "4.0.1",
@@ -7863,6 +8367,7 @@
         }
       },
       "System.Reflection.Emit.Lightweight/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Reflection.Emit.ILGeneration": "4.0.1",
@@ -7877,6 +8382,7 @@
         }
       },
       "System.Reflection.Extensions/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7892,6 +8398,7 @@
         }
       },
       "System.Reflection.Metadata/1.3.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections.Immutable": "1.2.0"
         },
@@ -7903,6 +8410,7 @@
         }
       },
       "System.Reflection.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7917,6 +8425,7 @@
         }
       },
       "System.Reflection.TypeExtensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Contracts": "4.0.1",
           "System.Diagnostics.Debug": "4.0.11",
@@ -7935,6 +8444,7 @@
         }
       },
       "System.Resources.ResourceManager/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7951,6 +8461,7 @@
         }
       },
       "System.Runtime/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7964,6 +8475,7 @@
         }
       },
       "System.Runtime.Extensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7978,6 +8490,7 @@
         }
       },
       "System.Runtime.Handles/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -7989,6 +8502,7 @@
         }
       },
       "System.Runtime.InteropServices/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -8006,6 +8520,7 @@
         }
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -8017,6 +8532,7 @@
         }
       },
       "System.Runtime.Numerics/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -8031,6 +8547,7 @@
         }
       },
       "System.Runtime.Serialization.Json/4.0.2": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Private.DataContractSerialization": "4.1.1",
@@ -8044,6 +8561,7 @@
         }
       },
       "System.Runtime.Serialization.Primitives/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.1",
           "System.Runtime": "4.1.0"
@@ -8056,6 +8574,7 @@
         }
       },
       "System.Runtime.Serialization.Xml/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Private.DataContractSerialization": "4.1.1",
@@ -8072,6 +8591,7 @@
         }
       },
       "System.Runtime.WindowsRuntime/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Diagnostics.Debug": "4.0.11",
@@ -8092,6 +8612,7 @@
         }
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Runtime.WindowsRuntime": "4.0.11"
@@ -8104,6 +8625,7 @@
         }
       },
       "System.Security.Claims/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -8121,6 +8643,7 @@
         }
       },
       "System.Security.Cryptography.Algorithms/4.2.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.IO": "4.1.0",
@@ -8141,6 +8664,7 @@
         }
       },
       "System.Security.Cryptography.Cng/4.2.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.IO": "4.1.0",
@@ -8162,6 +8686,7 @@
         }
       },
       "System.Security.Cryptography.Encoding/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -8184,6 +8709,7 @@
         }
       },
       "System.Security.Cryptography.Primitives/4.0.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -8201,6 +8727,7 @@
         }
       },
       "System.Security.Cryptography.X509Certificates/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -8229,6 +8756,7 @@
         }
       },
       "System.Security.Principal/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -8240,6 +8768,7 @@
         }
       },
       "System.ServiceModel.Duplex/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Private.ServiceModel": "4.1.0",
           "System.Runtime": "4.1.0",
@@ -8254,6 +8783,7 @@
         }
       },
       "System.ServiceModel.Http/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.11",
           "System.Net.WebHeaderCollection": "4.0.1",
@@ -8271,6 +8801,7 @@
         }
       },
       "System.ServiceModel.NetTcp/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.11",
           "System.Private.ServiceModel": "4.1.0",
@@ -8286,6 +8817,7 @@
         }
       },
       "System.ServiceModel.Primitives/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.ComponentModel.EventBasedAsync": "4.0.11",
@@ -8312,6 +8844,7 @@
         }
       },
       "System.ServiceModel.Security/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Private.ServiceModel": "4.1.0",
           "System.Runtime": "4.1.0",
@@ -8326,6 +8859,7 @@
         }
       },
       "System.Text.Encoding/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -8340,6 +8874,7 @@
         }
       },
       "System.Text.Encoding.CodePages/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -8362,6 +8897,7 @@
         }
       },
       "System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -8377,6 +8913,7 @@
         }
       },
       "System.Text.RegularExpressions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -8393,6 +8930,7 @@
         }
       },
       "System.Threading/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Threading.Tasks": "4.0.11"
@@ -8405,6 +8943,7 @@
         }
       },
       "System.Threading.Overlapped/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Resources.ResourceManager": "4.0.1",
@@ -8422,6 +8961,7 @@
         }
       },
       "System.Threading.Tasks/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -8436,6 +8976,7 @@
         }
       },
       "System.Threading.Tasks.Dataflow/4.6.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll": {}
         },
@@ -8444,6 +8985,7 @@
         }
       },
       "System.Threading.Tasks.Extensions/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/portable-net45+win8+wp8+wpa81/_._": {}
         },
@@ -8452,6 +8994,7 @@
         }
       },
       "System.Threading.Tasks.Parallel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.12",
           "System.Diagnostics.Debug": "4.0.11",
@@ -8470,6 +9013,7 @@
         }
       },
       "System.Threading.Timer/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -8484,6 +9028,7 @@
         }
       },
       "System.Xml.ReaderWriter/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -8509,6 +9054,7 @@
         }
       },
       "System.Xml.XDocument/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -8531,6 +9077,7 @@
         }
       },
       "System.Xml.XmlDocument/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -8551,6 +9098,7 @@
         }
       },
       "System.Xml.XmlSerializer/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -8576,10 +9124,14 @@
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
+      },
+      "Metropolis.UI.MVVM.Core/1.0.0": {
+        "type": "project"
       }
     },
     "UAP,Version=v10.0/win10-x64-aot": {
       "Microsoft.CSharp/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -8606,6 +9158,7 @@
         }
       },
       "Microsoft.NETCore/5.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.CSharp": "4.0.1",
           "Microsoft.NETCore.Platforms": "1.0.1",
@@ -8665,11 +9218,13 @@
         }
       },
       "Microsoft.NETCore.Jit/1.0.3": {
+        "type": "package",
         "dependencies": {
           "runtime.win7-x64.Microsoft.NETCore.Jit": "1.0.3"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.1": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.0/_._": {}
         },
@@ -8678,6 +9233,7 @@
         }
       },
       "Microsoft.NETCore.Portable.Compatibility/1.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
         },
@@ -8713,6 +9269,7 @@
         }
       },
       "Microsoft.NETCore.Runtime.CoreCLR/1.0.3": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Jit": "1.0.3",
           "Microsoft.NETCore.Windows.ApiSets": "1.0.1",
@@ -8720,6 +9277,7 @@
         }
       },
       "Microsoft.NETCore.Targets/1.0.2": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.0/_._": {}
         },
@@ -8728,6 +9286,7 @@
         }
       },
       "Microsoft.NETCore.UniversalWindowsPlatform/5.2.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore": "5.0.2",
           "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
@@ -8763,8 +9322,11 @@
           "System.Xml.XmlSerializer": "4.0.11"
         }
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {},
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {
+        "type": "package"
+      },
       "Microsoft.VisualBasic/10.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -8791,6 +9353,7 @@
         }
       },
       "Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -8802,12 +9365,14 @@
         }
       },
       "MvvmCross/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Binding": "4.3.0",
           "MvvmCross.Core": "4.3.0"
         }
       },
       "MvvmCross.Binding/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Core": "4.3.0"
         },
@@ -8821,6 +9386,7 @@
         }
       },
       "MvvmCross.Core/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Platform": "4.3.0"
         },
@@ -8834,6 +9400,7 @@
         }
       },
       "MvvmCross.Platform/4.3.0": {
+        "type": "package",
         "compile": {
           "lib/win81/MvvmCross.Platform.WindowsCommon.dll": {},
           "lib/win81/MvvmCross.Platform.dll": {}
@@ -8844,6 +9411,7 @@
         }
       },
       "runtime.aot.System.Collections/4.0.10": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -8859,6 +9427,7 @@
         }
       },
       "runtime.aot.System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -8867,6 +9436,7 @@
         }
       },
       "runtime.aot.System.Diagnostics.Tracing/4.0.20": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -8887,6 +9457,7 @@
         }
       },
       "runtime.aot.System.Globalization/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -8895,6 +9466,7 @@
         }
       },
       "runtime.aot.System.Globalization.Calendars/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -8903,6 +9475,7 @@
         }
       },
       "runtime.aot.System.IO/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.11",
           "System.Runtime": "4.1.0",
@@ -8919,6 +9492,7 @@
         }
       },
       "runtime.aot.System.Reflection/4.0.10": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -8927,6 +9501,7 @@
         }
       },
       "runtime.aot.System.Reflection.Extensions/4.0.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Reflection": "4.1.0",
@@ -8944,6 +9519,7 @@
         }
       },
       "runtime.aot.System.Reflection.Primitives/4.0.0": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Threading": "4.0.11"
@@ -8956,6 +9532,7 @@
         }
       },
       "runtime.aot.System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.11",
           "System.Reflection": "4.1.0",
@@ -8969,6 +9546,7 @@
         }
       },
       "runtime.aot.System.Runtime/4.0.20": {
+        "type": "package",
         "dependencies": {
           "System.Private.Uri": "4.0.1"
         },
@@ -8980,6 +9558,7 @@
         }
       },
       "runtime.aot.System.Runtime.Handles/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -8988,6 +9567,7 @@
         }
       },
       "runtime.aot.System.Runtime.InteropServices/4.0.20": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -8996,6 +9576,7 @@
         }
       },
       "runtime.aot.System.Text.Encoding/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -9004,6 +9585,7 @@
         }
       },
       "runtime.aot.System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -9012,6 +9594,7 @@
         }
       },
       "runtime.aot.System.Threading.Tasks/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -9020,6 +9603,7 @@
         }
       },
       "runtime.aot.System.Threading.Timer/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -9031,6 +9615,7 @@
         }
       },
       "runtime.native.System.IO.Compression/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -9044,6 +9629,7 @@
         }
       },
       "runtime.native.System.Security.Cryptography/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1"
@@ -9056,6 +9642,7 @@
         }
       },
       "runtime.win.Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Runtime.InteropServices": "4.1.0"
@@ -9068,6 +9655,7 @@
         }
       },
       "runtime.win.System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -9076,6 +9664,7 @@
         }
       },
       "runtime.win.System.IO.FileSystem/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -9101,6 +9690,7 @@
         }
       },
       "runtime.win.System.Net.Primitives/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.1",
           "System.Collections": "4.0.11",
@@ -9121,6 +9711,7 @@
         }
       },
       "runtime.win.System.Net.Sockets/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -9148,6 +9739,7 @@
         }
       },
       "runtime.win.System.Runtime.Extensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Private.Uri": "4.0.1"
         },
@@ -9159,6 +9751,7 @@
         }
       },
       "runtime.win10-x64-aot.runtime.native.System.IO.Compression/4.0.1": {
+        "type": "package",
         "compile": {
           "runtimes/win10-x64-aot/lib/netcore50/_._": {}
         },
@@ -9167,11 +9760,13 @@
         }
       },
       "runtime.win7-x64.Microsoft.NETCore.Jit/1.0.3": {
+        "type": "package",
         "native": {
           "runtimes/win7-x64-aot/native/_._": {}
         }
       },
       "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.2": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.0/_._": {}
         },
@@ -9183,6 +9778,7 @@
         }
       },
       "runtime.win7.System.Private.Uri/4.0.2": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -9191,6 +9787,7 @@
         }
       },
       "System.AppContext/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -9205,6 +9802,7 @@
         }
       },
       "System.Buffers/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.1/_._": {}
         },
@@ -9213,6 +9811,7 @@
         }
       },
       "System.Collections/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -9227,6 +9826,7 @@
         }
       },
       "System.Collections.Concurrent/4.0.12": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -9246,6 +9846,7 @@
         }
       },
       "System.Collections.Immutable/1.2.0": {
+        "type": "package",
         "compile": {
           "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
         },
@@ -9254,6 +9855,7 @@
         }
       },
       "System.Collections.NonGeneric/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -9270,6 +9872,7 @@
         }
       },
       "System.Collections.Specialized/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.1",
           "System.Globalization": "4.0.11",
@@ -9287,6 +9890,7 @@
         }
       },
       "System.ComponentModel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -9298,6 +9902,7 @@
         }
       },
       "System.ComponentModel.Annotations/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.ComponentModel": "4.0.1",
@@ -9319,6 +9924,7 @@
         }
       },
       "System.ComponentModel.EventBasedAsync/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.1",
           "System.Runtime": "4.1.0",
@@ -9333,6 +9939,7 @@
         }
       },
       "System.Data.Common/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.2/System.Data.Common.dll": {}
         },
@@ -9341,6 +9948,7 @@
         }
       },
       "System.Diagnostics.Contracts/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -9352,6 +9960,7 @@
         }
       },
       "System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -9366,6 +9975,7 @@
         }
       },
       "System.Diagnostics.DiagnosticSource/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.3/_._": {}
         },
@@ -9374,6 +9984,7 @@
         }
       },
       "System.Diagnostics.StackTrace/4.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1"
         },
@@ -9385,6 +9996,7 @@
         }
       },
       "System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -9399,6 +10011,7 @@
         }
       },
       "System.Diagnostics.Tracing/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -9413,6 +10026,7 @@
         }
       },
       "System.Dynamic.Runtime/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -9435,6 +10049,7 @@
         }
       },
       "System.Globalization/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -9449,6 +10064,7 @@
         }
       },
       "System.Globalization.Calendars/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -9461,6 +10077,7 @@
         }
       },
       "System.Globalization.Extensions/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Globalization": "4.0.11",
@@ -9477,6 +10094,7 @@
         }
       },
       "System.IO/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -9493,6 +10111,7 @@
         }
       },
       "System.IO.Compression/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -9515,6 +10134,7 @@
         }
       },
       "System.IO.Compression.ZipFile/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Buffers": "4.0.0",
           "System.IO": "4.1.0",
@@ -9534,6 +10154,7 @@
         }
       },
       "System.IO.FileSystem/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -9550,6 +10171,7 @@
         }
       },
       "System.IO.FileSystem.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -9561,6 +10183,7 @@
         }
       },
       "System.IO.IsolatedStorage/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.IO.FileSystem": "4.0.1",
@@ -9580,6 +10203,7 @@
         }
       },
       "System.IO.UnmanagedMemoryStream/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.IO.FileSystem.Primitives": "4.0.1",
@@ -9597,6 +10221,7 @@
         }
       },
       "System.Linq/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -9612,6 +10237,7 @@
         }
       },
       "System.Linq.Expressions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -9637,6 +10263,7 @@
         }
       },
       "System.Linq.Parallel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Collections.Concurrent": "4.0.12",
@@ -9657,6 +10284,7 @@
         }
       },
       "System.Linq.Queryable/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -9675,6 +10303,7 @@
         }
       },
       "System.Net.Http/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -9703,6 +10332,7 @@
         }
       },
       "System.Net.Http.Rtc/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Net.Http": "4.1.0",
@@ -9716,6 +10346,7 @@
         }
       },
       "System.Net.NameResolution/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -9738,6 +10369,7 @@
         }
       },
       "System.Net.NetworkInformation/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.Win32.Primitives": "4.0.1",
@@ -9761,6 +10393,7 @@
         }
       },
       "System.Net.Primitives/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -9776,6 +10409,7 @@
         }
       },
       "System.Net.Requests/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Net.Primitives": "4.0.11",
@@ -9791,6 +10425,7 @@
         }
       },
       "System.Net.Sockets/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -9805,6 +10440,7 @@
         }
       },
       "System.Net.WebHeaderCollection/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -9819,6 +10455,7 @@
         }
       },
       "System.Net.WebSockets/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.1",
           "System.Resources.ResourceManager": "4.0.1",
@@ -9833,6 +10470,7 @@
         }
       },
       "System.Net.WebSockets.Client/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -9860,6 +10498,7 @@
         }
       },
       "System.Numerics.Vectors/4.1.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.0/System.Numerics.Vectors.dll": {}
         },
@@ -9868,6 +10507,7 @@
         }
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Numerics.Vectors": "4.1.1",
           "System.Runtime": "4.1.0",
@@ -9881,6 +10521,7 @@
         }
       },
       "System.ObjectModel/4.0.12": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -9896,6 +10537,7 @@
         }
       },
       "System.Private.DataContractSerialization/4.1.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -9929,6 +10571,7 @@
         }
       },
       "System.Private.ServiceModel/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -9985,6 +10628,7 @@
         }
       },
       "System.Private.Uri/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -9995,6 +10639,7 @@
         }
       },
       "System.Reflection/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -10011,6 +10656,7 @@
         }
       },
       "System.Reflection.Context/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Runtime": "4.1.0"
@@ -10023,6 +10669,7 @@
         }
       },
       "System.Reflection.DispatchProxy/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Runtime": "4.1.0"
@@ -10035,6 +10682,7 @@
         }
       },
       "System.Reflection.Emit/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Reflection": "4.1.0",
@@ -10050,6 +10698,7 @@
         }
       },
       "System.Reflection.Emit.ILGeneration/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Reflection.Primitives": "4.0.1",
@@ -10063,6 +10712,7 @@
         }
       },
       "System.Reflection.Emit.Lightweight/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Reflection.Emit.ILGeneration": "4.0.1",
@@ -10077,6 +10727,7 @@
         }
       },
       "System.Reflection.Extensions/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -10092,6 +10743,7 @@
         }
       },
       "System.Reflection.Metadata/1.3.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections.Immutable": "1.2.0"
         },
@@ -10103,6 +10755,7 @@
         }
       },
       "System.Reflection.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -10117,6 +10770,7 @@
         }
       },
       "System.Reflection.TypeExtensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Contracts": "4.0.1",
           "System.Diagnostics.Debug": "4.0.11",
@@ -10135,6 +10789,7 @@
         }
       },
       "System.Resources.ResourceManager/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -10151,6 +10806,7 @@
         }
       },
       "System.Runtime/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -10164,6 +10820,7 @@
         }
       },
       "System.Runtime.Extensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -10178,6 +10835,7 @@
         }
       },
       "System.Runtime.Handles/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -10189,6 +10847,7 @@
         }
       },
       "System.Runtime.InteropServices/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -10206,6 +10865,7 @@
         }
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -10217,6 +10877,7 @@
         }
       },
       "System.Runtime.Numerics/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -10231,6 +10892,7 @@
         }
       },
       "System.Runtime.Serialization.Json/4.0.2": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Private.DataContractSerialization": "4.1.1",
@@ -10244,6 +10906,7 @@
         }
       },
       "System.Runtime.Serialization.Primitives/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.1",
           "System.Runtime": "4.1.0"
@@ -10256,6 +10919,7 @@
         }
       },
       "System.Runtime.Serialization.Xml/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Private.DataContractSerialization": "4.1.1",
@@ -10272,6 +10936,7 @@
         }
       },
       "System.Runtime.WindowsRuntime/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Diagnostics.Debug": "4.0.11",
@@ -10292,6 +10957,7 @@
         }
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Runtime.WindowsRuntime": "4.0.11"
@@ -10304,6 +10970,7 @@
         }
       },
       "System.Security.Claims/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -10321,6 +10988,7 @@
         }
       },
       "System.Security.Cryptography.Algorithms/4.2.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.IO": "4.1.0",
@@ -10341,6 +11009,7 @@
         }
       },
       "System.Security.Cryptography.Cng/4.2.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.IO": "4.1.0",
@@ -10362,6 +11031,7 @@
         }
       },
       "System.Security.Cryptography.Encoding/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -10384,6 +11054,7 @@
         }
       },
       "System.Security.Cryptography.Primitives/4.0.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -10401,6 +11072,7 @@
         }
       },
       "System.Security.Cryptography.X509Certificates/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -10429,6 +11101,7 @@
         }
       },
       "System.Security.Principal/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -10440,6 +11113,7 @@
         }
       },
       "System.ServiceModel.Duplex/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Private.ServiceModel": "4.1.0",
           "System.Runtime": "4.1.0",
@@ -10454,6 +11128,7 @@
         }
       },
       "System.ServiceModel.Http/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.11",
           "System.Net.WebHeaderCollection": "4.0.1",
@@ -10471,6 +11146,7 @@
         }
       },
       "System.ServiceModel.NetTcp/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.11",
           "System.Private.ServiceModel": "4.1.0",
@@ -10486,6 +11162,7 @@
         }
       },
       "System.ServiceModel.Primitives/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.ComponentModel.EventBasedAsync": "4.0.11",
@@ -10512,6 +11189,7 @@
         }
       },
       "System.ServiceModel.Security/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Private.ServiceModel": "4.1.0",
           "System.Runtime": "4.1.0",
@@ -10526,6 +11204,7 @@
         }
       },
       "System.Text.Encoding/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -10540,6 +11219,7 @@
         }
       },
       "System.Text.Encoding.CodePages/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -10562,6 +11242,7 @@
         }
       },
       "System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -10577,6 +11258,7 @@
         }
       },
       "System.Text.RegularExpressions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -10593,6 +11275,7 @@
         }
       },
       "System.Threading/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Threading.Tasks": "4.0.11"
@@ -10605,6 +11288,7 @@
         }
       },
       "System.Threading.Overlapped/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Resources.ResourceManager": "4.0.1",
@@ -10622,6 +11306,7 @@
         }
       },
       "System.Threading.Tasks/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -10636,6 +11321,7 @@
         }
       },
       "System.Threading.Tasks.Dataflow/4.6.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll": {}
         },
@@ -10644,6 +11330,7 @@
         }
       },
       "System.Threading.Tasks.Extensions/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/portable-net45+win8+wp8+wpa81/_._": {}
         },
@@ -10652,6 +11339,7 @@
         }
       },
       "System.Threading.Tasks.Parallel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.12",
           "System.Diagnostics.Debug": "4.0.11",
@@ -10670,6 +11358,7 @@
         }
       },
       "System.Threading.Timer/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -10684,6 +11373,7 @@
         }
       },
       "System.Xml.ReaderWriter/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -10709,6 +11399,7 @@
         }
       },
       "System.Xml.XDocument/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -10731,6 +11422,7 @@
         }
       },
       "System.Xml.XmlDocument/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -10751,6 +11443,7 @@
         }
       },
       "System.Xml.XmlSerializer/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -10776,10 +11469,14 @@
         "runtime": {
           "runtimes/aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
+      },
+      "Metropolis.UI.MVVM.Core/1.0.0": {
+        "type": "project"
       }
     },
     "UAP,Version=v10.0/win10-x86": {
       "Microsoft.CSharp/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -10806,6 +11503,7 @@
         }
       },
       "Microsoft.NETCore/5.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.CSharp": "4.0.1",
           "Microsoft.NETCore.Platforms": "1.0.1",
@@ -10865,11 +11563,13 @@
         }
       },
       "Microsoft.NETCore.Jit/1.0.3": {
+        "type": "package",
         "dependencies": {
           "runtime.win7-x86.Microsoft.NETCore.Jit": "1.0.3"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.1": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.0/_._": {}
         },
@@ -10878,6 +11578,7 @@
         }
       },
       "Microsoft.NETCore.Portable.Compatibility/1.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
         },
@@ -10912,6 +11613,7 @@
         }
       },
       "Microsoft.NETCore.Runtime.CoreCLR/1.0.3": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Jit": "1.0.3",
           "Microsoft.NETCore.Windows.ApiSets": "1.0.1",
@@ -10919,6 +11621,7 @@
         }
       },
       "Microsoft.NETCore.Targets/1.0.2": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.0/_._": {}
         },
@@ -10927,6 +11630,7 @@
         }
       },
       "Microsoft.NETCore.UniversalWindowsPlatform/5.2.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore": "5.0.2",
           "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
@@ -10962,8 +11666,11 @@
           "System.Xml.XmlSerializer": "4.0.11"
         }
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {},
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {
+        "type": "package"
+      },
       "Microsoft.VisualBasic/10.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -10990,6 +11697,7 @@
         }
       },
       "Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -11001,12 +11709,14 @@
         }
       },
       "MvvmCross/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Binding": "4.3.0",
           "MvvmCross.Core": "4.3.0"
         }
       },
       "MvvmCross.Binding/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Core": "4.3.0"
         },
@@ -11020,6 +11730,7 @@
         }
       },
       "MvvmCross.Core/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Platform": "4.3.0"
         },
@@ -11033,6 +11744,7 @@
         }
       },
       "MvvmCross.Platform/4.3.0": {
+        "type": "package",
         "compile": {
           "lib/win81/MvvmCross.Platform.WindowsCommon.dll": {},
           "lib/win81/MvvmCross.Platform.dll": {}
@@ -11043,6 +11755,7 @@
         }
       },
       "runtime.any.System.Collections/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -11054,6 +11767,7 @@
         }
       },
       "runtime.any.System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11062,6 +11776,7 @@
         }
       },
       "runtime.any.System.Diagnostics.Tracing/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11070,6 +11785,7 @@
         }
       },
       "runtime.any.System.Globalization/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11078,6 +11794,7 @@
         }
       },
       "runtime.any.System.Globalization.Calendars/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11086,6 +11803,7 @@
         }
       },
       "runtime.any.System.IO/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11094,6 +11812,7 @@
         }
       },
       "runtime.any.System.Reflection/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11102,6 +11821,7 @@
         }
       },
       "runtime.any.System.Reflection.Extensions/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11110,6 +11830,7 @@
         }
       },
       "runtime.any.System.Reflection.Primitives/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11118,6 +11839,7 @@
         }
       },
       "runtime.any.System.Resources.ResourceManager/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11126,6 +11848,7 @@
         }
       },
       "runtime.any.System.Runtime/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Private.Uri": "4.0.1"
         },
@@ -11137,6 +11860,7 @@
         }
       },
       "runtime.any.System.Runtime.Handles/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11145,6 +11869,7 @@
         }
       },
       "runtime.any.System.Runtime.InteropServices/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11153,6 +11878,7 @@
         }
       },
       "runtime.any.System.Text.Encoding/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11161,6 +11887,7 @@
         }
       },
       "runtime.any.System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11169,6 +11896,7 @@
         }
       },
       "runtime.any.System.Threading.Tasks/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11177,6 +11905,7 @@
         }
       },
       "runtime.any.System.Threading.Timer/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11185,6 +11914,7 @@
         }
       },
       "runtime.native.System.IO.Compression/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -11198,6 +11928,7 @@
         }
       },
       "runtime.native.System.Security.Cryptography/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1"
@@ -11210,6 +11941,7 @@
         }
       },
       "runtime.win.Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Runtime.InteropServices": "4.1.0"
@@ -11222,6 +11954,7 @@
         }
       },
       "runtime.win.System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11230,6 +11963,7 @@
         }
       },
       "runtime.win.System.IO.FileSystem/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -11255,6 +11989,7 @@
         }
       },
       "runtime.win.System.Net.Primitives/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.1",
           "System.Collections": "4.0.11",
@@ -11275,6 +12010,7 @@
         }
       },
       "runtime.win.System.Net.Sockets/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -11302,6 +12038,7 @@
         }
       },
       "runtime.win.System.Runtime.Extensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Private.Uri": "4.0.1"
         },
@@ -11313,11 +12050,13 @@
         }
       },
       "runtime.win7-x86.Microsoft.NETCore.Jit/1.0.3": {
+        "type": "package",
         "native": {
           "runtimes/win7-x86/native/clrjit.dll": {}
         }
       },
       "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.2": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.0/_._": {}
         },
@@ -11339,11 +12078,13 @@
         }
       },
       "runtime.win7-x86.runtime.native.System.IO.Compression/4.0.1": {
+        "type": "package",
         "native": {
           "runtimes/win7-x86/native/clrcompression.dll": {}
         }
       },
       "runtime.win7.System.Private.Uri/4.0.2": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -11352,6 +12093,7 @@
         }
       },
       "System.AppContext/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -11366,6 +12108,7 @@
         }
       },
       "System.Buffers/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.1/_._": {}
         },
@@ -11374,6 +12117,7 @@
         }
       },
       "System.Collections/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -11388,6 +12132,7 @@
         }
       },
       "System.Collections.Concurrent/4.0.12": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -11407,6 +12152,7 @@
         }
       },
       "System.Collections.Immutable/1.2.0": {
+        "type": "package",
         "compile": {
           "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
         },
@@ -11415,6 +12161,7 @@
         }
       },
       "System.Collections.NonGeneric/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -11431,6 +12178,7 @@
         }
       },
       "System.Collections.Specialized/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.1",
           "System.Globalization": "4.0.11",
@@ -11448,6 +12196,7 @@
         }
       },
       "System.ComponentModel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -11459,6 +12208,7 @@
         }
       },
       "System.ComponentModel.Annotations/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.ComponentModel": "4.0.1",
@@ -11480,6 +12230,7 @@
         }
       },
       "System.ComponentModel.EventBasedAsync/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.1",
           "System.Runtime": "4.1.0",
@@ -11494,6 +12245,7 @@
         }
       },
       "System.Data.Common/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.2/System.Data.Common.dll": {}
         },
@@ -11502,6 +12254,7 @@
         }
       },
       "System.Diagnostics.Contracts/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -11513,6 +12266,7 @@
         }
       },
       "System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -11527,6 +12281,7 @@
         }
       },
       "System.Diagnostics.DiagnosticSource/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.3/_._": {}
         },
@@ -11535,6 +12290,7 @@
         }
       },
       "System.Diagnostics.StackTrace/4.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1"
         },
@@ -11546,6 +12302,7 @@
         }
       },
       "System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -11560,6 +12317,7 @@
         }
       },
       "System.Diagnostics.Tracing/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -11574,6 +12332,7 @@
         }
       },
       "System.Dynamic.Runtime/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -11596,6 +12355,7 @@
         }
       },
       "System.Globalization/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -11610,6 +12370,7 @@
         }
       },
       "System.Globalization.Calendars/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -11622,6 +12383,7 @@
         }
       },
       "System.Globalization.Extensions/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Globalization": "4.0.11",
@@ -11638,6 +12400,7 @@
         }
       },
       "System.IO/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -11654,6 +12417,7 @@
         }
       },
       "System.IO.Compression/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -11676,6 +12440,7 @@
         }
       },
       "System.IO.Compression.ZipFile/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Buffers": "4.0.0",
           "System.IO": "4.1.0",
@@ -11695,6 +12460,7 @@
         }
       },
       "System.IO.FileSystem/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -11711,6 +12477,7 @@
         }
       },
       "System.IO.FileSystem.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -11722,6 +12489,7 @@
         }
       },
       "System.IO.IsolatedStorage/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.IO.FileSystem": "4.0.1",
@@ -11741,6 +12509,7 @@
         }
       },
       "System.IO.UnmanagedMemoryStream/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.IO.FileSystem.Primitives": "4.0.1",
@@ -11758,6 +12527,7 @@
         }
       },
       "System.Linq/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -11773,6 +12543,7 @@
         }
       },
       "System.Linq.Expressions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -11798,6 +12569,7 @@
         }
       },
       "System.Linq.Parallel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Collections.Concurrent": "4.0.12",
@@ -11818,6 +12590,7 @@
         }
       },
       "System.Linq.Queryable/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -11836,6 +12609,7 @@
         }
       },
       "System.Net.Http/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -11864,6 +12638,7 @@
         }
       },
       "System.Net.Http.Rtc/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Net.Http": "4.1.0",
@@ -11877,6 +12652,7 @@
         }
       },
       "System.Net.NameResolution/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -11899,6 +12675,7 @@
         }
       },
       "System.Net.NetworkInformation/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.Win32.Primitives": "4.0.1",
@@ -11922,6 +12699,7 @@
         }
       },
       "System.Net.Primitives/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -11937,6 +12715,7 @@
         }
       },
       "System.Net.Requests/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Net.Primitives": "4.0.11",
@@ -11952,6 +12731,7 @@
         }
       },
       "System.Net.Sockets/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -11966,6 +12746,7 @@
         }
       },
       "System.Net.WebHeaderCollection/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -11980,6 +12761,7 @@
         }
       },
       "System.Net.WebSockets/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.1",
           "System.Resources.ResourceManager": "4.0.1",
@@ -11994,6 +12776,7 @@
         }
       },
       "System.Net.WebSockets.Client/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -12021,6 +12804,7 @@
         }
       },
       "System.Numerics.Vectors/4.1.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.0/System.Numerics.Vectors.dll": {}
         },
@@ -12029,6 +12813,7 @@
         }
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Numerics.Vectors": "4.1.1",
           "System.Runtime": "4.1.0",
@@ -12042,6 +12827,7 @@
         }
       },
       "System.ObjectModel/4.0.12": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -12057,6 +12843,7 @@
         }
       },
       "System.Private.DataContractSerialization/4.1.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -12090,6 +12877,7 @@
         }
       },
       "System.Private.ServiceModel/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -12146,6 +12934,7 @@
         }
       },
       "System.Private.Uri/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12156,6 +12945,7 @@
         }
       },
       "System.Reflection/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12172,6 +12962,7 @@
         }
       },
       "System.Reflection.Context/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Runtime": "4.1.0"
@@ -12184,6 +12975,7 @@
         }
       },
       "System.Reflection.DispatchProxy/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Runtime": "4.1.0"
@@ -12196,6 +12988,7 @@
         }
       },
       "System.Reflection.Emit/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Reflection": "4.1.0",
@@ -12211,6 +13004,7 @@
         }
       },
       "System.Reflection.Emit.ILGeneration/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Reflection.Primitives": "4.0.1",
@@ -12224,6 +13018,7 @@
         }
       },
       "System.Reflection.Emit.Lightweight/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Reflection.Emit.ILGeneration": "4.0.1",
@@ -12238,6 +13033,7 @@
         }
       },
       "System.Reflection.Extensions/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12253,6 +13049,7 @@
         }
       },
       "System.Reflection.Metadata/1.3.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections.Immutable": "1.2.0"
         },
@@ -12264,6 +13061,7 @@
         }
       },
       "System.Reflection.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12278,6 +13076,7 @@
         }
       },
       "System.Reflection.TypeExtensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Contracts": "4.0.1",
           "System.Diagnostics.Debug": "4.0.11",
@@ -12296,6 +13095,7 @@
         }
       },
       "System.Resources.ResourceManager/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12312,6 +13112,7 @@
         }
       },
       "System.Runtime/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12325,6 +13126,7 @@
         }
       },
       "System.Runtime.Extensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12339,6 +13141,7 @@
         }
       },
       "System.Runtime.Handles/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12350,6 +13153,7 @@
         }
       },
       "System.Runtime.InteropServices/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12367,6 +13171,7 @@
         }
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -12378,6 +13183,7 @@
         }
       },
       "System.Runtime.Numerics/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -12392,6 +13198,7 @@
         }
       },
       "System.Runtime.Serialization.Json/4.0.2": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Private.DataContractSerialization": "4.1.1",
@@ -12405,6 +13212,7 @@
         }
       },
       "System.Runtime.Serialization.Primitives/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.1",
           "System.Runtime": "4.1.0"
@@ -12417,6 +13225,7 @@
         }
       },
       "System.Runtime.Serialization.Xml/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Private.DataContractSerialization": "4.1.1",
@@ -12433,6 +13242,7 @@
         }
       },
       "System.Runtime.WindowsRuntime/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Diagnostics.Debug": "4.0.11",
@@ -12453,6 +13263,7 @@
         }
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Runtime.WindowsRuntime": "4.0.11"
@@ -12465,6 +13276,7 @@
         }
       },
       "System.Security.Claims/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -12482,6 +13294,7 @@
         }
       },
       "System.Security.Cryptography.Algorithms/4.2.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.IO": "4.1.0",
@@ -12502,6 +13315,7 @@
         }
       },
       "System.Security.Cryptography.Cng/4.2.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.IO": "4.1.0",
@@ -12523,6 +13337,7 @@
         }
       },
       "System.Security.Cryptography.Encoding/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -12545,6 +13360,7 @@
         }
       },
       "System.Security.Cryptography.Primitives/4.0.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -12562,6 +13378,7 @@
         }
       },
       "System.Security.Cryptography.X509Certificates/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -12590,6 +13407,7 @@
         }
       },
       "System.Security.Principal/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -12601,6 +13419,7 @@
         }
       },
       "System.ServiceModel.Duplex/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Private.ServiceModel": "4.1.0",
           "System.Runtime": "4.1.0",
@@ -12615,6 +13434,7 @@
         }
       },
       "System.ServiceModel.Http/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.11",
           "System.Net.WebHeaderCollection": "4.0.1",
@@ -12632,6 +13452,7 @@
         }
       },
       "System.ServiceModel.NetTcp/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.11",
           "System.Private.ServiceModel": "4.1.0",
@@ -12647,6 +13468,7 @@
         }
       },
       "System.ServiceModel.Primitives/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.ComponentModel.EventBasedAsync": "4.0.11",
@@ -12673,6 +13495,7 @@
         }
       },
       "System.ServiceModel.Security/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Private.ServiceModel": "4.1.0",
           "System.Runtime": "4.1.0",
@@ -12687,6 +13510,7 @@
         }
       },
       "System.Text.Encoding/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12701,6 +13525,7 @@
         }
       },
       "System.Text.Encoding.CodePages/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -12723,6 +13548,7 @@
         }
       },
       "System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12738,6 +13564,7 @@
         }
       },
       "System.Text.RegularExpressions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -12754,6 +13581,7 @@
         }
       },
       "System.Threading/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Threading.Tasks": "4.0.11"
@@ -12766,6 +13594,7 @@
         }
       },
       "System.Threading.Overlapped/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Resources.ResourceManager": "4.0.1",
@@ -12783,6 +13612,7 @@
         }
       },
       "System.Threading.Tasks/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12797,6 +13627,7 @@
         }
       },
       "System.Threading.Tasks.Dataflow/4.6.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll": {}
         },
@@ -12805,6 +13636,7 @@
         }
       },
       "System.Threading.Tasks.Extensions/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/portable-net45+win8+wp8+wpa81/_._": {}
         },
@@ -12813,6 +13645,7 @@
         }
       },
       "System.Threading.Tasks.Parallel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.12",
           "System.Diagnostics.Debug": "4.0.11",
@@ -12831,6 +13664,7 @@
         }
       },
       "System.Threading.Timer/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -12845,6 +13679,7 @@
         }
       },
       "System.Xml.ReaderWriter/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -12870,6 +13705,7 @@
         }
       },
       "System.Xml.XDocument/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -12892,6 +13728,7 @@
         }
       },
       "System.Xml.XmlDocument/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -12912,6 +13749,7 @@
         }
       },
       "System.Xml.XmlSerializer/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -12937,10 +13775,14 @@
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
+      },
+      "Metropolis.UI.MVVM.Core/1.0.0": {
+        "type": "project"
       }
     },
     "UAP,Version=v10.0/win10-x86-aot": {
       "Microsoft.CSharp/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -12967,6 +13809,7 @@
         }
       },
       "Microsoft.NETCore/5.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.CSharp": "4.0.1",
           "Microsoft.NETCore.Platforms": "1.0.1",
@@ -13026,11 +13869,13 @@
         }
       },
       "Microsoft.NETCore.Jit/1.0.3": {
+        "type": "package",
         "dependencies": {
           "runtime.win7-x86.Microsoft.NETCore.Jit": "1.0.3"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.1": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.0/_._": {}
         },
@@ -13039,6 +13884,7 @@
         }
       },
       "Microsoft.NETCore.Portable.Compatibility/1.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
         },
@@ -13074,6 +13920,7 @@
         }
       },
       "Microsoft.NETCore.Runtime.CoreCLR/1.0.3": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Jit": "1.0.3",
           "Microsoft.NETCore.Windows.ApiSets": "1.0.1",
@@ -13081,6 +13928,7 @@
         }
       },
       "Microsoft.NETCore.Targets/1.0.2": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.0/_._": {}
         },
@@ -13089,6 +13937,7 @@
         }
       },
       "Microsoft.NETCore.UniversalWindowsPlatform/5.2.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore": "5.0.2",
           "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
@@ -13124,8 +13973,11 @@
           "System.Xml.XmlSerializer": "4.0.11"
         }
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {},
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1": {
+        "type": "package"
+      },
       "Microsoft.VisualBasic/10.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -13152,6 +14004,7 @@
         }
       },
       "Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -13163,12 +14016,14 @@
         }
       },
       "MvvmCross/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Binding": "4.3.0",
           "MvvmCross.Core": "4.3.0"
         }
       },
       "MvvmCross.Binding/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Core": "4.3.0"
         },
@@ -13182,6 +14037,7 @@
         }
       },
       "MvvmCross.Core/4.3.0": {
+        "type": "package",
         "dependencies": {
           "MvvmCross.Platform": "4.3.0"
         },
@@ -13195,6 +14051,7 @@
         }
       },
       "MvvmCross.Platform/4.3.0": {
+        "type": "package",
         "compile": {
           "lib/win81/MvvmCross.Platform.WindowsCommon.dll": {},
           "lib/win81/MvvmCross.Platform.dll": {}
@@ -13205,6 +14062,7 @@
         }
       },
       "runtime.aot.System.Collections/4.0.10": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -13220,6 +14078,7 @@
         }
       },
       "runtime.aot.System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -13228,6 +14087,7 @@
         }
       },
       "runtime.aot.System.Diagnostics.Tracing/4.0.20": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -13248,6 +14108,7 @@
         }
       },
       "runtime.aot.System.Globalization/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -13256,6 +14117,7 @@
         }
       },
       "runtime.aot.System.Globalization.Calendars/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -13264,6 +14126,7 @@
         }
       },
       "runtime.aot.System.IO/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.11",
           "System.Runtime": "4.1.0",
@@ -13280,6 +14143,7 @@
         }
       },
       "runtime.aot.System.Reflection/4.0.10": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -13288,6 +14152,7 @@
         }
       },
       "runtime.aot.System.Reflection.Extensions/4.0.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Reflection": "4.1.0",
@@ -13305,6 +14170,7 @@
         }
       },
       "runtime.aot.System.Reflection.Primitives/4.0.0": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Threading": "4.0.11"
@@ -13317,6 +14183,7 @@
         }
       },
       "runtime.aot.System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.11",
           "System.Reflection": "4.1.0",
@@ -13330,6 +14197,7 @@
         }
       },
       "runtime.aot.System.Runtime/4.0.20": {
+        "type": "package",
         "dependencies": {
           "System.Private.Uri": "4.0.1"
         },
@@ -13341,6 +14209,7 @@
         }
       },
       "runtime.aot.System.Runtime.Handles/4.0.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -13349,6 +14218,7 @@
         }
       },
       "runtime.aot.System.Runtime.InteropServices/4.0.20": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -13357,6 +14227,7 @@
         }
       },
       "runtime.aot.System.Text.Encoding/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -13365,6 +14236,7 @@
         }
       },
       "runtime.aot.System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -13373,6 +14245,7 @@
         }
       },
       "runtime.aot.System.Threading.Tasks/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -13381,6 +14254,7 @@
         }
       },
       "runtime.aot.System.Threading.Timer/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -13392,6 +14266,7 @@
         }
       },
       "runtime.native.System.IO.Compression/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -13405,6 +14280,7 @@
         }
       },
       "runtime.native.System.Security.Cryptography/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1"
@@ -13417,6 +14293,7 @@
         }
       },
       "runtime.win.Microsoft.Win32.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Runtime.InteropServices": "4.1.0"
@@ -13429,6 +14306,7 @@
         }
       },
       "runtime.win.System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -13437,6 +14315,7 @@
         }
       },
       "runtime.win.System.IO.FileSystem/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -13462,6 +14341,7 @@
         }
       },
       "runtime.win.System.Net.Primitives/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.1",
           "System.Collections": "4.0.11",
@@ -13482,6 +14362,7 @@
         }
       },
       "runtime.win.System.Net.Sockets/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -13509,6 +14390,7 @@
         }
       },
       "runtime.win.System.Runtime.Extensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Private.Uri": "4.0.1"
         },
@@ -13520,6 +14402,7 @@
         }
       },
       "runtime.win10-x86-aot.runtime.native.System.IO.Compression/4.0.1": {
+        "type": "package",
         "compile": {
           "runtimes/win10-x86-aot/lib/netcore50/_._": {}
         },
@@ -13528,11 +14411,13 @@
         }
       },
       "runtime.win7-x86.Microsoft.NETCore.Jit/1.0.3": {
+        "type": "package",
         "native": {
           "runtimes/win7-x86-aot/native/_._": {}
         }
       },
       "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.2": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.0/_._": {}
         },
@@ -13544,6 +14429,7 @@
         }
       },
       "runtime.win7.System.Private.Uri/4.0.2": {
+        "type": "package",
         "compile": {
           "ref/netstandard/_._": {}
         },
@@ -13552,6 +14438,7 @@
         }
       },
       "System.AppContext/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -13566,6 +14453,7 @@
         }
       },
       "System.Buffers/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.1/_._": {}
         },
@@ -13574,6 +14462,7 @@
         }
       },
       "System.Collections/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -13588,6 +14477,7 @@
         }
       },
       "System.Collections.Concurrent/4.0.12": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -13607,6 +14497,7 @@
         }
       },
       "System.Collections.Immutable/1.2.0": {
+        "type": "package",
         "compile": {
           "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
         },
@@ -13615,6 +14506,7 @@
         }
       },
       "System.Collections.NonGeneric/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -13631,6 +14523,7 @@
         }
       },
       "System.Collections.Specialized/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.1",
           "System.Globalization": "4.0.11",
@@ -13648,6 +14541,7 @@
         }
       },
       "System.ComponentModel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -13659,6 +14553,7 @@
         }
       },
       "System.ComponentModel.Annotations/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.ComponentModel": "4.0.1",
@@ -13680,6 +14575,7 @@
         }
       },
       "System.ComponentModel.EventBasedAsync/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.1",
           "System.Runtime": "4.1.0",
@@ -13694,6 +14590,7 @@
         }
       },
       "System.Data.Common/4.1.0": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.2/System.Data.Common.dll": {}
         },
@@ -13702,6 +14599,7 @@
         }
       },
       "System.Diagnostics.Contracts/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -13713,6 +14611,7 @@
         }
       },
       "System.Diagnostics.Debug/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -13727,6 +14626,7 @@
         }
       },
       "System.Diagnostics.DiagnosticSource/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.3/_._": {}
         },
@@ -13735,6 +14635,7 @@
         }
       },
       "System.Diagnostics.StackTrace/4.0.2": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1"
         },
@@ -13746,6 +14647,7 @@
         }
       },
       "System.Diagnostics.Tools/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -13760,6 +14662,7 @@
         }
       },
       "System.Diagnostics.Tracing/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -13774,6 +14677,7 @@
         }
       },
       "System.Dynamic.Runtime/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -13796,6 +14700,7 @@
         }
       },
       "System.Globalization/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -13810,6 +14715,7 @@
         }
       },
       "System.Globalization.Calendars/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -13822,6 +14728,7 @@
         }
       },
       "System.Globalization.Extensions/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Globalization": "4.0.11",
@@ -13838,6 +14745,7 @@
         }
       },
       "System.IO/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -13854,6 +14762,7 @@
         }
       },
       "System.IO.Compression/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -13876,6 +14785,7 @@
         }
       },
       "System.IO.Compression.ZipFile/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Buffers": "4.0.0",
           "System.IO": "4.1.0",
@@ -13895,6 +14805,7 @@
         }
       },
       "System.IO.FileSystem/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -13911,6 +14822,7 @@
         }
       },
       "System.IO.FileSystem.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -13922,6 +14834,7 @@
         }
       },
       "System.IO.IsolatedStorage/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.IO.FileSystem": "4.0.1",
@@ -13941,6 +14854,7 @@
         }
       },
       "System.IO.UnmanagedMemoryStream/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.IO.FileSystem.Primitives": "4.0.1",
@@ -13958,6 +14872,7 @@
         }
       },
       "System.Linq/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -13973,6 +14888,7 @@
         }
       },
       "System.Linq.Expressions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -13998,6 +14914,7 @@
         }
       },
       "System.Linq.Parallel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Collections.Concurrent": "4.0.12",
@@ -14018,6 +14935,7 @@
         }
       },
       "System.Linq.Queryable/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -14036,6 +14954,7 @@
         }
       },
       "System.Net.Http/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -14064,6 +14983,7 @@
         }
       },
       "System.Net.Http.Rtc/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Net.Http": "4.1.0",
@@ -14077,6 +14997,7 @@
         }
       },
       "System.Net.NameResolution/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -14099,6 +15020,7 @@
         }
       },
       "System.Net.NetworkInformation/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.Win32.Primitives": "4.0.1",
@@ -14122,6 +15044,7 @@
         }
       },
       "System.Net.Primitives/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14137,6 +15060,7 @@
         }
       },
       "System.Net.Requests/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Net.Primitives": "4.0.11",
@@ -14152,6 +15076,7 @@
         }
       },
       "System.Net.Sockets/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14166,6 +15091,7 @@
         }
       },
       "System.Net.WebHeaderCollection/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -14180,6 +15106,7 @@
         }
       },
       "System.Net.WebSockets/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.1",
           "System.Resources.ResourceManager": "4.0.1",
@@ -14194,6 +15121,7 @@
         }
       },
       "System.Net.WebSockets.Client/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -14221,6 +15149,7 @@
         }
       },
       "System.Numerics.Vectors/4.1.1": {
+        "type": "package",
         "compile": {
           "ref/netstandard1.0/System.Numerics.Vectors.dll": {}
         },
@@ -14229,6 +15158,7 @@
         }
       },
       "System.Numerics.Vectors.WindowsRuntime/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Numerics.Vectors": "4.1.1",
           "System.Runtime": "4.1.0",
@@ -14242,6 +15172,7 @@
         }
       },
       "System.ObjectModel/4.0.12": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -14257,6 +15188,7 @@
         }
       },
       "System.Private.DataContractSerialization/4.1.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -14290,6 +15222,7 @@
         }
       },
       "System.Private.ServiceModel/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -14346,6 +15279,7 @@
         }
       },
       "System.Private.Uri/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14356,6 +15290,7 @@
         }
       },
       "System.Reflection/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14372,6 +15307,7 @@
         }
       },
       "System.Reflection.Context/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Runtime": "4.1.0"
@@ -14384,6 +15320,7 @@
         }
       },
       "System.Reflection.DispatchProxy/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Runtime": "4.1.0"
@@ -14396,6 +15333,7 @@
         }
       },
       "System.Reflection.Emit/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Reflection": "4.1.0",
@@ -14411,6 +15349,7 @@
         }
       },
       "System.Reflection.Emit.ILGeneration/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Reflection.Primitives": "4.0.1",
@@ -14424,6 +15363,7 @@
         }
       },
       "System.Reflection.Emit.Lightweight/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Reflection": "4.1.0",
           "System.Reflection.Emit.ILGeneration": "4.0.1",
@@ -14438,6 +15378,7 @@
         }
       },
       "System.Reflection.Extensions/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14453,6 +15394,7 @@
         }
       },
       "System.Reflection.Metadata/1.3.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections.Immutable": "1.2.0"
         },
@@ -14464,6 +15406,7 @@
         }
       },
       "System.Reflection.Primitives/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14478,6 +15421,7 @@
         }
       },
       "System.Reflection.TypeExtensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Contracts": "4.0.1",
           "System.Diagnostics.Debug": "4.0.11",
@@ -14496,6 +15440,7 @@
         }
       },
       "System.Resources.ResourceManager/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14512,6 +15457,7 @@
         }
       },
       "System.Runtime/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14525,6 +15471,7 @@
         }
       },
       "System.Runtime.Extensions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14539,6 +15486,7 @@
         }
       },
       "System.Runtime.Handles/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14550,6 +15498,7 @@
         }
       },
       "System.Runtime.InteropServices/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14567,6 +15516,7 @@
         }
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -14578,6 +15528,7 @@
         }
       },
       "System.Runtime.Numerics/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.11",
           "System.Resources.ResourceManager": "4.0.1",
@@ -14592,6 +15543,7 @@
         }
       },
       "System.Runtime.Serialization.Json/4.0.2": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Private.DataContractSerialization": "4.1.1",
@@ -14605,6 +15557,7 @@
         }
       },
       "System.Runtime.Serialization.Primitives/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.1",
           "System.Runtime": "4.1.0"
@@ -14617,6 +15570,7 @@
         }
       },
       "System.Runtime.Serialization.Xml/4.1.1": {
+        "type": "package",
         "dependencies": {
           "System.IO": "4.1.0",
           "System.Private.DataContractSerialization": "4.1.1",
@@ -14633,6 +15587,7 @@
         }
       },
       "System.Runtime.WindowsRuntime/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Diagnostics.Debug": "4.0.11",
@@ -14653,6 +15608,7 @@
         }
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Runtime.WindowsRuntime": "4.0.11"
@@ -14665,6 +15621,7 @@
         }
       },
       "System.Security.Claims/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -14682,6 +15639,7 @@
         }
       },
       "System.Security.Cryptography.Algorithms/4.2.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.IO": "4.1.0",
@@ -14702,6 +15660,7 @@
         }
       },
       "System.Security.Cryptography.Cng/4.2.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.IO": "4.1.0",
@@ -14723,6 +15682,7 @@
         }
       },
       "System.Security.Cryptography.Encoding/4.0.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -14745,6 +15705,7 @@
         }
       },
       "System.Security.Cryptography.Primitives/4.0.0": {
+        "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -14762,6 +15723,7 @@
         }
       },
       "System.Security.Cryptography.X509Certificates/4.1.0": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -14790,6 +15752,7 @@
         }
       },
       "System.Security.Principal/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0"
         },
@@ -14801,6 +15764,7 @@
         }
       },
       "System.ServiceModel.Duplex/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Private.ServiceModel": "4.1.0",
           "System.Runtime": "4.1.0",
@@ -14815,6 +15779,7 @@
         }
       },
       "System.ServiceModel.Http/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.11",
           "System.Net.WebHeaderCollection": "4.0.1",
@@ -14832,6 +15797,7 @@
         }
       },
       "System.ServiceModel.NetTcp/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.11",
           "System.Private.ServiceModel": "4.1.0",
@@ -14847,6 +15813,7 @@
         }
       },
       "System.ServiceModel.Primitives/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.ComponentModel.EventBasedAsync": "4.0.11",
@@ -14873,6 +15840,7 @@
         }
       },
       "System.ServiceModel.Security/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Private.ServiceModel": "4.1.0",
           "System.Runtime": "4.1.0",
@@ -14887,6 +15855,7 @@
         }
       },
       "System.Text.Encoding/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14901,6 +15870,7 @@
         }
       },
       "System.Text.Encoding.CodePages/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Collections": "4.0.11",
@@ -14923,6 +15893,7 @@
         }
       },
       "System.Text.Encoding.Extensions/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14938,6 +15909,7 @@
         }
       },
       "System.Text.RegularExpressions/4.1.0": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -14954,6 +15926,7 @@
         }
       },
       "System.Threading/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Runtime": "4.1.0",
           "System.Threading.Tasks": "4.0.11"
@@ -14966,6 +15939,7 @@
         }
       },
       "System.Threading.Overlapped/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "System.Resources.ResourceManager": "4.0.1",
@@ -14983,6 +15957,7 @@
         }
       },
       "System.Threading.Tasks/4.0.11": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -14997,6 +15972,7 @@
         }
       },
       "System.Threading.Tasks.Dataflow/4.6.0": {
+        "type": "package",
         "compile": {
           "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll": {}
         },
@@ -15005,6 +15981,7 @@
         }
       },
       "System.Threading.Tasks.Extensions/4.0.0": {
+        "type": "package",
         "compile": {
           "lib/portable-net45+win8+wp8+wpa81/_._": {}
         },
@@ -15013,6 +15990,7 @@
         }
       },
       "System.Threading.Tasks.Parallel/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.12",
           "System.Diagnostics.Debug": "4.0.11",
@@ -15031,6 +16009,7 @@
         }
       },
       "System.Threading.Timer/4.0.1": {
+        "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
@@ -15045,6 +16024,7 @@
         }
       },
       "System.Xml.ReaderWriter/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -15070,6 +16050,7 @@
         }
       },
       "System.Xml.XDocument/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -15092,6 +16073,7 @@
         }
       },
       "System.Xml.XmlDocument/4.0.1": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Diagnostics.Debug": "4.0.11",
@@ -15112,6 +16094,7 @@
         }
       },
       "System.Xml.XmlSerializer/4.0.11": {
+        "type": "package",
         "dependencies": {
           "System.Collections": "4.0.11",
           "System.Globalization": "4.0.11",
@@ -15137,16 +16120,18 @@
         "runtime": {
           "runtimes/aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
+      },
+      "Metropolis.UI.MVVM.Core/1.0.0": {
+        "type": "project"
       }
     }
   },
   "libraries": {
     "Microsoft.CSharp/4.0.1": {
-      "sha512": "17h8b5mXa87XYKrrVqdgZ38JefSUqLChUQpXgSnpzsM0nDOhE40FTeNWOJ/YmySGV6tG6T8+hjz6vxbknHJr6A==",
+      "sha512": "tqGuuGppNDib/ZGm6yRPFo30o4FI3d0YqFYjBPP0SFjPDgDn65VDLCxsCSyUXomR30ks6UwrXZPAGK5vxf7mcw==",
       "type": "package",
+      "path": "microsoft.csharp/4.0.1",
       "files": [
-        "Microsoft.CSharp.4.0.1.nupkg.sha512",
-        "Microsoft.CSharp.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -15162,6 +16147,8 @@
         "lib/xamarinmac20/_._",
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
+        "microsoft.csharp.4.0.1.nupkg.sha512",
+        "microsoft.csharp.nuspec",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
@@ -15200,42 +16187,44 @@
     "Microsoft.NETCore/5.0.2": {
       "sha512": "wHb/fpL+6IxrZBAL2BwRJmj51RwYr3TVcnw5KIsxUtqLxjsqgasTbBmE9kZPAlhhljnt+m2EYMc7vcFuAhGNqA==",
       "type": "package",
+      "path": "microsoft.netcore/5.0.2",
       "files": [
-        "Microsoft.NETCore.5.0.2.nupkg.sha512",
-        "Microsoft.NETCore.nuspec",
         "ThirdPartyNotices.txt",
-        "dotnet_library_license.txt"
+        "dotnet_library_license.txt",
+        "microsoft.netcore.5.0.2.nupkg.sha512",
+        "microsoft.netcore.nuspec"
       ]
     },
     "Microsoft.NETCore.Jit/1.0.3": {
       "sha512": "/l8xYwtoJrFSx9zMWRClaKrgR+BTstCD1E5P90ADgiwH0GwlEqVhLoFIrsXpYj0j9vCB/fzOq7D/ZzuCbtmrTQ==",
       "type": "package",
+      "path": "microsoft.netcore.jit/1.0.3",
       "files": [
-        "Microsoft.NETCore.Jit.1.0.3.nupkg.sha512",
-        "Microsoft.NETCore.Jit.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
+        "microsoft.netcore.jit.1.0.3.nupkg.sha512",
+        "microsoft.netcore.jit.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.Platforms/1.0.1": {
-      "sha512": "2G6OjjJzwBfNOO8myRV/nFrbTw5iA+DEm0N+qUqhrOmaVtn4pC77h38I1jsXGw5VH55+dPfQsqHD0We9sCl9FQ==",
+      "sha512": "T/TV7JI4A0YR39UTow+HCDBgxyEXwaRhBQjylU1oEQ/U393fmsY7msR9cyWFntiaAm8JecwLRQcLchAdYrFEaQ==",
       "type": "package",
+      "path": "microsoft.netcore.platforms/1.0.1",
       "files": [
-        "Microsoft.NETCore.Platforms.1.0.1.nupkg.sha512",
-        "Microsoft.NETCore.Platforms.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/netstandard1.0/_._",
+        "microsoft.netcore.platforms.1.0.1.nupkg.sha512",
+        "microsoft.netcore.platforms.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.Portable.Compatibility/1.0.2": {
       "sha512": "sR4m1GQ8Tbg+Xdbf8Y8yC+LXKSUJUVe/B5vckCAU9Jd5MYf84gC1D0u2YeA72B4WjeWewCyHRB20ddA8hyLmqQ==",
       "type": "package",
+      "path": "microsoft.netcore.portable.compatibility/1.0.2",
       "files": [
-        "Microsoft.NETCore.Portable.Compatibility.1.0.2.nupkg.sha512",
-        "Microsoft.NETCore.Portable.Compatibility.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/net45/_._",
@@ -15266,6 +16255,8 @@
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "microsoft.netcore.portable.compatibility.1.0.2.nupkg.sha512",
+        "microsoft.netcore.portable.compatibility.nuspec",
         "ref/net45/_._",
         "ref/netcore50/System.ComponentModel.DataAnnotations.dll",
         "ref/netcore50/System.Core.dll",
@@ -15314,53 +16305,56 @@
     "Microsoft.NETCore.Runtime.CoreCLR/1.0.3": {
       "sha512": "tjD5r9Lxy+MD+YRJcuds5+sT+xGHkVt2Hb5LfLZIgkFmwUewBRPm/42UXi4oxhV1OIdRtt4ymwsiuFCwT16T9w==",
       "type": "package",
+      "path": "microsoft.netcore.runtime.coreclr/1.0.3",
       "files": [
-        "Microsoft.NETCore.Runtime.CoreCLR.1.0.3.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
+        "microsoft.netcore.runtime.coreclr.1.0.3.nupkg.sha512",
+        "microsoft.netcore.runtime.coreclr.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.Targets/1.0.2": {
       "sha512": "yk4GtuNbFz2sxA5NNIp2bnOwGZVlB4U+F4gWy5YnMEKmGzzJfQ4wg7zQUx334+WMQ5PiQEuS4UuOpsW+V0PzVg==",
       "type": "package",
+      "path": "microsoft.netcore.targets/1.0.2",
       "files": [
-        "Microsoft.NETCore.Targets.1.0.2.nupkg.sha512",
-        "Microsoft.NETCore.Targets.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/netstandard1.0/_._",
+        "microsoft.netcore.targets.1.0.2.nupkg.sha512",
+        "microsoft.netcore.targets.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.UniversalWindowsPlatform/5.2.2": {
       "sha512": "9UHv2YObWmcF8gqtBoDC4UW5gdHzFRtaZ5KtB9QKvCy+NC9LH1DMYyOI/ltupjVZlwYEulj3msjBXys9/QI6nw==",
       "type": "package",
+      "path": "microsoft.netcore.universalwindowsplatform/5.2.2",
       "files": [
-        "Microsoft.NETCore.UniversalWindowsPlatform.5.2.2.nupkg.sha512",
-        "Microsoft.NETCore.UniversalWindowsPlatform.nuspec",
         "ThirdPartyNotices.txt",
-        "dotnet_library_license.txt"
+        "dotnet_library_license.txt",
+        "microsoft.netcore.universalwindowsplatform.5.2.2.nupkg.sha512",
+        "microsoft.netcore.universalwindowsplatform.nuspec"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets/1.0.1": {
-      "sha512": "SaToCvvsGMxTgtLv/BrFQ5IFMPRE1zpWbnqbpwykJa8W5XiX82CXI6K2o7yf5xS7EP6t/JzFLV0SIDuWpvBZVw==",
+      "sha512": "3M0tki7zw/SDn/2R7RbECQV3u99wLccRtzyS0mWjDSniK+0i8XfjrBvTG/m1I7DhO07LjRyLdXzQQlcjEImAAw==",
       "type": "package",
+      "path": "microsoft.netcore.windows.apisets/1.0.1",
       "files": [
-        "Microsoft.NETCore.Windows.ApiSets.1.0.1.nupkg.sha512",
-        "Microsoft.NETCore.Windows.ApiSets.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
+        "microsoft.netcore.windows.apisets.1.0.1.nupkg.sha512",
+        "microsoft.netcore.windows.apisets.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.VisualBasic/10.0.1": {
-      "sha512": "HpNyOf/4Tp2lh4FyywB55VITk0SqVxEjDzsVDDyF1yafDN6Bq18xcHowzCPINyYHUTgGcEtmpYiRsFdSo0KKdQ==",
+      "sha512": "A3sb5qdAOY4rYSSOHWSBmfaAuFzkwEFH5mIhU7oFrQSu+DfmrN72XhocYbgxStc0LVWxY3hS+Gnk3H2VZQspww==",
       "type": "package",
+      "path": "microsoft.visualbasic/10.0.1",
       "files": [
-        "Microsoft.VisualBasic.10.0.1.nupkg.sha512",
-        "Microsoft.VisualBasic.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/net45/_._",
@@ -15369,6 +16363,8 @@
         "lib/portable-net45+win8+wpa81/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "microsoft.visualbasic.10.0.1.nupkg.sha512",
+        "microsoft.visualbasic.nuspec",
         "ref/net45/_._",
         "ref/netcore50/Microsoft.VisualBasic.dll",
         "ref/netcore50/Microsoft.VisualBasic.xml",
@@ -15398,11 +16394,10 @@
       ]
     },
     "Microsoft.Win32.Primitives/4.0.1": {
-      "sha512": "fQnBHO9DgcmkC9dYSJoBqo6sH1VJwJprUHh8F3hbcRlxiQiBUuTntdk8tUwV490OqC2kQUrinGwZyQHTieuXRA==",
+      "sha512": "hnz7EaPQmQPK+Y4W1WRljBosDpIuBAse55PhqSdbZh8Qf1+GuQr8giYaZd1B4CdsbH4GzBXrPSUST4oAdhET8Q==",
       "type": "package",
+      "path": "microsoft.win32.primitives/4.0.1",
       "files": [
-        "Microsoft.Win32.Primitives.4.0.1.nupkg.sha512",
-        "Microsoft.Win32.Primitives.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -15412,6 +16407,8 @@
         "lib/xamarinmac20/_._",
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
+        "microsoft.win32.primitives.4.0.1.nupkg.sha512",
+        "microsoft.win32.primitives.nuspec",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/Microsoft.Win32.Primitives.dll",
@@ -15435,17 +16432,17 @@
     "MvvmCross/4.3.0": {
       "sha512": "22UBSqBq6R3vUwxcgVSFPnCybmrFpzXZRkkUKScPdzl+/pdzQJG1EOzmvaRvfvl+5fG11WINx5BAteFj+Cm+tQ==",
       "type": "package",
+      "path": "mvvmcross/4.3.0",
       "files": [
-        "MvvmCross.4.3.0.nupkg.sha512",
-        "MvvmCross.nuspec"
+        "mvvmcross.4.3.0.nupkg.sha512",
+        "mvvmcross.nuspec"
       ]
     },
     "MvvmCross.Binding/4.3.0": {
       "sha512": "cybvfGAGVt9q5ZIWMra7FIeNMjUb9h4qYSE2PrGtuEoNRDsLL+BaaC8JhbdodumKioapBDQd95PDnJaC1AqNWg==",
       "type": "package",
+      "path": "mvvmcross.binding/4.3.0",
       "files": [
-        "MvvmCross.Binding.4.3.0.nupkg.sha512",
-        "MvvmCross.Binding.nuspec",
         "lib/MonoAndroid/MvvmCross.Binding.Droid.dll",
         "lib/MonoAndroid/MvvmCross.Binding.dll",
         "lib/MonoAndroid/MvvmCross.Binding.dll.mdb",
@@ -15494,15 +16491,16 @@
         "lib/wpa81/MvvmCross.Binding.dll",
         "lib/wpa81/MvvmCross.Binding.dll.mdb",
         "lib/wpa81/MvvmCross.Localization.dll",
-        "lib/wpa81/MvvmCross.Localization.dll.mdb"
+        "lib/wpa81/MvvmCross.Localization.dll.mdb",
+        "mvvmcross.binding.4.3.0.nupkg.sha512",
+        "mvvmcross.binding.nuspec"
       ]
     },
     "MvvmCross.Core/4.3.0": {
       "sha512": "Th4Hcgvy8j7CkV0AFJaSnEH9Woe0C6FyqiWMrVPYQ9Trkv3NoJKvQ+JmuJ/jiLeXZv/HzWf+B/omhJB2wY4pKw==",
       "type": "package",
+      "path": "mvvmcross.core/4.3.0",
       "files": [
-        "MvvmCross.Core.4.3.0.nupkg.sha512",
-        "MvvmCross.Core.nuspec",
         "lib/MonoAndroid/MvvmCross.Core.dll",
         "lib/MonoAndroid/MvvmCross.Droid.Shared.dll",
         "lib/MonoAndroid/MvvmCross.Droid.dll",
@@ -15533,15 +16531,16 @@
         "lib/wp8/MvvmCross.WindowsPhone.dll",
         "lib/wpa81/MvvmCross.Core.dll",
         "lib/wpa81/MvvmCross.WindowsCommon.dll",
-        "lib/wpa81/MvvmCross.WindowsCommon.pri"
+        "lib/wpa81/MvvmCross.WindowsCommon.pri",
+        "mvvmcross.core.4.3.0.nupkg.sha512",
+        "mvvmcross.core.nuspec"
       ]
     },
     "MvvmCross.Platform/4.3.0": {
       "sha512": "sXFi2TSj94NSZQTGwaNozVjFIcMQk6h1jQkdgLw1P1nxEPyu7I7tgtiFIoGsvbX17fsAjd/9+ffl9Pj9X/C5Yw==",
       "type": "package",
+      "path": "mvvmcross.platform/4.3.0",
       "files": [
-        "MvvmCross.Platform.4.3.0.nupkg.sha512",
-        "MvvmCross.Platform.nuspec",
         "lib/MonoAndroid/MvvmCross.Platform.Droid.dll",
         "lib/MonoAndroid/MvvmCross.Platform.dll",
         "lib/MonoAndroid/MvvmCross.Platform.dll.mdb",
@@ -15578,12 +16577,15 @@
         "lib/wpa81/MvvmCross.Platform.WindowsCommon.dll",
         "lib/wpa81/MvvmCross.Platform.WindowsCommon.pri",
         "lib/wpa81/MvvmCross.Platform.dll",
-        "lib/wpa81/MvvmCross.Platform.dll.mdb"
+        "lib/wpa81/MvvmCross.Platform.dll.mdb",
+        "mvvmcross.platform.4.3.0.nupkg.sha512",
+        "mvvmcross.platform.nuspec"
       ]
     },
     "runtime.any.System.Collections/4.0.11": {
       "sha512": "MTBT/hu37Dm2042H1JjWSaMd8w+oPJ4ZWAbDNeLzC4ZHdqwHloP07KvD6+4VbwipDqY5obfFFy90mZYCaPDh5Q==",
       "type": "package",
+      "path": "runtime.any.system.collections/4.0.11",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15600,14 +16602,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Collections.4.0.11.nupkg.sha512",
-        "runtime.any.System.Collections.nuspec",
+        "runtime.any.system.collections.4.0.11.nupkg.sha512",
+        "runtime.any.system.collections.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Diagnostics.Tools/4.0.1": {
       "sha512": "GJkwEYbKw7qG29QrKMIEEZEGWxC+DQboeObhaM6WPKKgwk9Od8Qt8lWhr/+5xW3FF60TdMfjjUP8Zu6Y41wIkA==",
       "type": "package",
+      "path": "runtime.any.system.diagnostics.tools/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15624,14 +16627,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Diagnostics.Tools.4.0.1.nupkg.sha512",
-        "runtime.any.System.Diagnostics.Tools.nuspec",
+        "runtime.any.system.diagnostics.tools.4.0.1.nupkg.sha512",
+        "runtime.any.system.diagnostics.tools.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Diagnostics.Tracing/4.1.0": {
       "sha512": "x7VLOl/v504jX97YEMePamZRHA3cJPOFY/xLw9pgjDr0Q3IQIZ+0K4oiKKtQrfMYSvOAntkzw+EvvQ+OWGRL9w==",
       "type": "package",
+      "path": "runtime.any.system.diagnostics.tracing/4.1.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15648,14 +16652,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Diagnostics.Tracing.4.1.0.nupkg.sha512",
-        "runtime.any.System.Diagnostics.Tracing.nuspec",
+        "runtime.any.system.diagnostics.tracing.4.1.0.nupkg.sha512",
+        "runtime.any.system.diagnostics.tracing.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Globalization/4.0.11": {
       "sha512": "cjJ3+b83Tpf02AIc5FkGj1vzY68RnsVHiGLrOCc5n7gpNVg1JnZrt1mcY99ykQ/wr3nCdvSP2pYvdxbYsxZdlA==",
       "type": "package",
+      "path": "runtime.any.system.globalization/4.0.11",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15672,14 +16677,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Globalization.4.0.11.nupkg.sha512",
-        "runtime.any.System.Globalization.nuspec",
+        "runtime.any.system.globalization.4.0.11.nupkg.sha512",
+        "runtime.any.system.globalization.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Globalization.Calendars/4.0.1": {
       "sha512": "SAdVwIKKKR3VG9NMKEgF+wbAKkQA60YOb4G9YGj4EUPsuwS+pH7FjjG6qQeXDyOaxUcrlRzI3LHcGloX/GHBxQ==",
       "type": "package",
+      "path": "runtime.any.system.globalization.calendars/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15693,14 +16699,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Globalization.Calendars.4.0.1.nupkg.sha512",
-        "runtime.any.System.Globalization.Calendars.nuspec",
+        "runtime.any.system.globalization.calendars.4.0.1.nupkg.sha512",
+        "runtime.any.system.globalization.calendars.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.IO/4.1.0": {
       "sha512": "sC7zKVdhYQEtrREKBJf4zkUwNdi6fsbkzrhJLDIAxIxD+YA5PABAQJps13zxpA1Ke3AgzOA9551JDymAfmRuTg==",
       "type": "package",
+      "path": "runtime.any.system.io/4.1.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15717,14 +16724,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.IO.4.1.0.nupkg.sha512",
-        "runtime.any.System.IO.nuspec",
+        "runtime.any.system.io.4.1.0.nupkg.sha512",
+        "runtime.any.system.io.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Reflection/4.1.0": {
       "sha512": "eKq6/GprEINYbugjWf2V9cjkyuAH/y+Raed28PJQ35zd30oR/pvKEHNN8JbPAgzYpI09TCd1yuhXN/Rb8PM8GA==",
       "type": "package",
+      "path": "runtime.any.system.reflection/4.1.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15741,14 +16749,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Reflection.4.1.0.nupkg.sha512",
-        "runtime.any.System.Reflection.nuspec",
+        "runtime.any.system.reflection.4.1.0.nupkg.sha512",
+        "runtime.any.system.reflection.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Reflection.Extensions/4.0.1": {
       "sha512": "ajAAD1MHX4KSNq/CW0d1IMlq5seVTuzTMMhA5EFWagMejfamzljIL92/wD19eK/1mPuux5nb16K4PFBYQrZOrQ==",
       "type": "package",
+      "path": "runtime.any.system.reflection.extensions/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15765,14 +16774,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Reflection.Extensions.4.0.1.nupkg.sha512",
-        "runtime.any.System.Reflection.Extensions.nuspec",
+        "runtime.any.system.reflection.extensions.4.0.1.nupkg.sha512",
+        "runtime.any.system.reflection.extensions.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Reflection.Primitives/4.0.1": {
       "sha512": "oKs78h11WDhCGFNpxT26IqL8Oo8OBzr6YOW0WG+R14FGaB/WDM5UHiK/jr6dipdnO8Wxlg/U48ka6uaPM6l53w==",
       "type": "package",
+      "path": "runtime.any.system.reflection.primitives/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15789,14 +16799,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Reflection.Primitives.4.0.1.nupkg.sha512",
-        "runtime.any.System.Reflection.Primitives.nuspec",
+        "runtime.any.system.reflection.primitives.4.0.1.nupkg.sha512",
+        "runtime.any.system.reflection.primitives.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Resources.ResourceManager/4.0.1": {
       "sha512": "hes7WFTOERydB/hLGmLj66NbK7I2AnjLHEeTpf7EmPZOIrRWeuC1dPoFYC9XRVIVzfCcOZI7oXM7KXe4vakt9Q==",
       "type": "package",
+      "path": "runtime.any.system.resources.resourcemanager/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15813,14 +16824,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Resources.ResourceManager.4.0.1.nupkg.sha512",
-        "runtime.any.System.Resources.ResourceManager.nuspec",
+        "runtime.any.system.resources.resourcemanager.4.0.1.nupkg.sha512",
+        "runtime.any.system.resources.resourcemanager.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Runtime/4.1.0": {
       "sha512": "0QVLwEGXROl0Trt2XosEjly9uqXcjHKStoZyZG9twJYFZJqq2JJXcBMXl/fnyQAgYEEODV8lUsU+t7NCCY0nUQ==",
       "type": "package",
+      "path": "runtime.any.system.runtime/4.1.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15837,14 +16849,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Runtime.4.1.0.nupkg.sha512",
-        "runtime.any.System.Runtime.nuspec",
+        "runtime.any.system.runtime.4.1.0.nupkg.sha512",
+        "runtime.any.system.runtime.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Runtime.Handles/4.0.1": {
       "sha512": "MZ5fVmAE/3S11wt3hPfn3RsAHppj5gUz+VZuLQkRjLCMSlX0krOI601IZsMWc3CoxUb+wMt3gZVb/mEjblw6Mg==",
       "type": "package",
+      "path": "runtime.any.system.runtime.handles/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15857,14 +16870,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Runtime.Handles.4.0.1.nupkg.sha512",
-        "runtime.any.System.Runtime.Handles.nuspec",
+        "runtime.any.system.runtime.handles.4.0.1.nupkg.sha512",
+        "runtime.any.system.runtime.handles.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Runtime.InteropServices/4.1.0": {
       "sha512": "gmibdZ9x/eB6hf5le33DWLCQbhcIUD2vqoc0tBgqSUWlB8YjEzVJXyTPDO+ypKLlL90Kv3ZDrK7yPCNqcyhqCA==",
       "type": "package",
+      "path": "runtime.any.system.runtime.interopservices/4.1.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15880,14 +16894,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Runtime.InteropServices.4.1.0.nupkg.sha512",
-        "runtime.any.System.Runtime.InteropServices.nuspec",
+        "runtime.any.system.runtime.interopservices.4.1.0.nupkg.sha512",
+        "runtime.any.system.runtime.interopservices.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Text.Encoding/4.0.11": {
       "sha512": "uweRMRDD4O8Iy8m4h1cJvoFIHNCzHMpipuxkRNAMML6EMzAhDCQTjgvRwki7PlUg8RGY1ctXnBZjT1rXvMZuRw==",
       "type": "package",
+      "path": "runtime.any.system.text.encoding/4.0.11",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15903,14 +16918,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Text.Encoding.4.0.11.nupkg.sha512",
-        "runtime.any.System.Text.Encoding.nuspec",
+        "runtime.any.system.text.encoding.4.0.11.nupkg.sha512",
+        "runtime.any.system.text.encoding.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Text.Encoding.Extensions/4.0.11": {
       "sha512": "3n6qbf59NMgA7F9S+q9gmqFV7T/CtAZw2pa6aprfdZxUinR2mDvVchsgthoacpQvAQu6e3ok8WWeypSu/yjXrA==",
       "type": "package",
+      "path": "runtime.any.system.text.encoding.extensions/4.0.11",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15926,14 +16942,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Text.Encoding.Extensions.4.0.11.nupkg.sha512",
-        "runtime.any.System.Text.Encoding.Extensions.nuspec",
+        "runtime.any.system.text.encoding.extensions.4.0.11.nupkg.sha512",
+        "runtime.any.system.text.encoding.extensions.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Threading.Tasks/4.0.11": {
       "sha512": "CEvWO0IwtdCAsmCb9aAl59psy0hzx+whYh4DzbjNb0GsQmxw/G7bZEcrBtE8c9QupNVbu87c2xaMi6p4r1bpjA==",
       "type": "package",
+      "path": "runtime.any.system.threading.tasks/4.0.11",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15950,14 +16967,15 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Threading.Tasks.4.0.11.nupkg.sha512",
-        "runtime.any.System.Threading.Tasks.nuspec",
+        "runtime.any.system.threading.tasks.4.0.11.nupkg.sha512",
+        "runtime.any.system.threading.tasks.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Threading.Timer/4.0.1": {
       "sha512": "C9d5eRAW/gd5iBZF78JRcwjvjCDRfU0oB48/wx/XbKnONZU4k6hWneTT4M7v3TmVqPFl7UDcLzKCtQ/24efOzw==",
       "type": "package",
+      "path": "runtime.any.system.threading.timer/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -15973,80 +16991,86 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Threading.Timer.4.0.1.nupkg.sha512",
-        "runtime.any.System.Threading.Timer.nuspec",
+        "runtime.any.system.threading.timer.4.0.1.nupkg.sha512",
+        "runtime.any.system.threading.timer.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.aot.System.Collections/4.0.10": {
       "sha512": "JaNCSMYW8RoPTrzlqRp3IsPdbSp8IhnNQ3qeKVGtBggT/9bZFz6FjfU+YG3NEiy/yPo03NMQ5EtXMT2MCIrV1A==",
       "type": "package",
+      "path": "runtime.aot.system.collections/4.0.10",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Collections.4.0.10.nupkg.sha512",
-        "runtime.aot.System.Collections.nuspec",
+        "runtime.aot.system.collections.4.0.10.nupkg.sha512",
+        "runtime.aot.system.collections.nuspec",
         "runtimes/aot/lib/netcore50/System.Collections.dll"
       ]
     },
     "runtime.aot.System.Diagnostics.Tools/4.0.1": {
       "sha512": "29xXSZEpRNd2wJsEXX40CEaWhhQjfqFGal4f1DuqY7Gd7+ARcV7zJK9aKRX9SkHnQfx3qSm3+D/VWBPI7pgEYQ==",
       "type": "package",
+      "path": "runtime.aot.system.diagnostics.tools/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Diagnostics.Tools.4.0.1.nupkg.sha512",
-        "runtime.aot.System.Diagnostics.Tools.nuspec",
+        "runtime.aot.system.diagnostics.tools.4.0.1.nupkg.sha512",
+        "runtime.aot.system.diagnostics.tools.nuspec",
         "runtimes/aot/lib/netcore50/System.Diagnostics.Tools.dll"
       ]
     },
     "runtime.aot.System.Diagnostics.Tracing/4.0.20": {
       "sha512": "1zaLtCd4/msBeR4hDRjywdONAqnMl+mfsYO2er+kj9HEMQfrItSdApImXakl3CTRqb1S8upuBru2v/SLEY2vtg==",
       "type": "package",
+      "path": "runtime.aot.system.diagnostics.tracing/4.0.20",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Diagnostics.Tracing.4.0.20.nupkg.sha512",
-        "runtime.aot.System.Diagnostics.Tracing.nuspec",
+        "runtime.aot.system.diagnostics.tracing.4.0.20.nupkg.sha512",
+        "runtime.aot.system.diagnostics.tracing.nuspec",
         "runtimes/aot/lib/netcore50/System.Diagnostics.Tracing.dll"
       ]
     },
     "runtime.aot.System.Globalization/4.0.11": {
       "sha512": "eEPSEA2yUp1HLNlp8Cve/J6UpN2mFnWUJhjqVEw+d+JUkWrzE2+ebl+0kf91Nwls4Mnia0GkjRRDiDKt8XeAAQ==",
       "type": "package",
+      "path": "runtime.aot.system.globalization/4.0.11",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Globalization.4.0.11.nupkg.sha512",
-        "runtime.aot.System.Globalization.nuspec",
+        "runtime.aot.system.globalization.4.0.11.nupkg.sha512",
+        "runtime.aot.system.globalization.nuspec",
         "runtimes/aot/lib/netcore50/System.Globalization.dll"
       ]
     },
     "runtime.aot.System.Globalization.Calendars/4.0.1": {
       "sha512": "nXHH2LS832GzQMr//792HTXyuUGlREv/8IZ24USS+q8QobtPwAis0mDumSoSd6z+IoiFGK7ol1Ev/ab+dRiVTg==",
       "type": "package",
+      "path": "runtime.aot.system.globalization.calendars/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Globalization.Calendars.4.0.1.nupkg.sha512",
-        "runtime.aot.System.Globalization.Calendars.nuspec",
+        "runtime.aot.system.globalization.calendars.4.0.1.nupkg.sha512",
+        "runtime.aot.system.globalization.calendars.nuspec",
         "runtimes/aot/lib/netcore50/System.Globalization.Calendars.dll"
       ]
     },
     "runtime.aot.System.IO/4.1.0": {
       "sha512": "zI0PBKDpAvTNbxTgcZutcb50D7jHJaC9vQLxKhUBn4gS7VHQqnZjqyEqXBxc4rnx6rdZzlMADNZAMUWNW42Sxw==",
       "type": "package",
+      "path": "runtime.aot.system.io/4.1.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.IO.4.1.0.nupkg.sha512",
-        "runtime.aot.System.IO.nuspec",
+        "runtime.aot.system.io.4.1.0.nupkg.sha512",
+        "runtime.aot.system.io.nuspec",
         "runtimes/aot/lib/netcore50/System.IO.dll",
         "runtimes/aot/lib/netstandard1.3/System.IO.dll"
       ]
@@ -16054,36 +17078,39 @@
     "runtime.aot.System.Reflection/4.0.10": {
       "sha512": "vrUbKdxXRNkmIsiMFP03cKLmzGoN7ObqU7rpjr/9ABL2ovHO7vyFhVfkpUXg4uX94ixgVaytbISLe+yxFQtl8w==",
       "type": "package",
+      "path": "runtime.aot.system.reflection/4.0.10",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Reflection.4.0.10.nupkg.sha512",
-        "runtime.aot.System.Reflection.nuspec",
+        "runtime.aot.system.reflection.4.0.10.nupkg.sha512",
+        "runtime.aot.system.reflection.nuspec",
         "runtimes/aot/lib/netcore50/System.Reflection.dll"
       ]
     },
     "runtime.aot.System.Reflection.Extensions/4.0.0": {
       "sha512": "WWw59m7k4XZLWN6XbptSR0TOdrLgwh5XEBj77QaUZQ+PcmvSzdJ79Jfp76ncQb5SzJZVu5ByZ7ufWX2bIeDpFQ==",
       "type": "package",
+      "path": "runtime.aot.system.reflection.extensions/4.0.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Reflection.Extensions.4.0.0.nupkg.sha512",
-        "runtime.aot.System.Reflection.Extensions.nuspec",
+        "runtime.aot.system.reflection.extensions.4.0.0.nupkg.sha512",
+        "runtime.aot.system.reflection.extensions.nuspec",
         "runtimes/aot/lib/netcore50/System.Reflection.Extensions.dll"
       ]
     },
     "runtime.aot.System.Reflection.Primitives/4.0.0": {
       "sha512": "826QEny5/GvZ270fhG70vnzYlFnTxNAHiHfyRS2zMZ5X1MpAsiW0y0XHAJjq7MrrnRjyG3qHF0zqytpNPJLaFQ==",
       "type": "package",
+      "path": "runtime.aot.system.reflection.primitives/4.0.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Reflection.Primitives.4.0.0.nupkg.sha512",
-        "runtime.aot.System.Reflection.Primitives.nuspec",
+        "runtime.aot.system.reflection.primitives.4.0.0.nupkg.sha512",
+        "runtime.aot.system.reflection.primitives.nuspec",
         "runtimes/aot/lib/MonoAndroid10/_._",
         "runtimes/aot/lib/MonoTouch10/_._",
         "runtimes/aot/lib/net45/_._",
@@ -16100,130 +17127,141 @@
     "runtime.aot.System.Resources.ResourceManager/4.0.0": {
       "sha512": "j+xK1M/oJ5ll7WT6UD9oQ/YUESFtT0YN3th1TIliJjK5J0Ek4vDPTMDQceu3WFy7aQOThDmIxjkAVSxZV7OWIA==",
       "type": "package",
+      "path": "runtime.aot.system.resources.resourcemanager/4.0.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Resources.ResourceManager.4.0.0.nupkg.sha512",
-        "runtime.aot.System.Resources.ResourceManager.nuspec",
+        "runtime.aot.system.resources.resourcemanager.4.0.0.nupkg.sha512",
+        "runtime.aot.system.resources.resourcemanager.nuspec",
         "runtimes/aot/lib/netcore50/System.Resources.ResourceManager.dll"
       ]
     },
     "runtime.aot.System.Runtime/4.0.20": {
       "sha512": "ax423Smc+2Bcm8Go70iwj30hpjUIuahVtBAqlGXzhOoRwRR4vlEN3OGp8qTecWki3ZhGrbOXy+A1U89V3DzG/w==",
       "type": "package",
+      "path": "runtime.aot.system.runtime/4.0.20",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Runtime.4.0.20.nupkg.sha512",
-        "runtime.aot.System.Runtime.nuspec",
+        "runtime.aot.system.runtime.4.0.20.nupkg.sha512",
+        "runtime.aot.system.runtime.nuspec",
         "runtimes/aot/lib/netcore50/System.Runtime.dll"
       ]
     },
     "runtime.aot.System.Runtime.Handles/4.0.1": {
       "sha512": "UPzDQF5lwQ+BN+B1Zu2u3b5YQvIo4A96N9v5Uwo4VL1hWEf4STqiZgRogumy21TeRLjtEpF7I5JqIDhcc3OMCw==",
       "type": "package",
+      "path": "runtime.aot.system.runtime.handles/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Runtime.Handles.4.0.1.nupkg.sha512",
-        "runtime.aot.System.Runtime.Handles.nuspec",
+        "runtime.aot.system.runtime.handles.4.0.1.nupkg.sha512",
+        "runtime.aot.system.runtime.handles.nuspec",
         "runtimes/aot/lib/netcore50/System.Runtime.Handles.dll"
       ]
     },
     "runtime.aot.System.Runtime.InteropServices/4.0.20": {
       "sha512": "s4P2Jlf6ev4RgeLjNIq4hXsESIuE6t0Ljf+KVfRGDvrZ+yJuoPjwS3zMkm2SPj5Qif1HZ9vskKTdHPtk1B89Bw==",
       "type": "package",
+      "path": "runtime.aot.system.runtime.interopservices/4.0.20",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Runtime.InteropServices.4.0.20.nupkg.sha512",
-        "runtime.aot.System.Runtime.InteropServices.nuspec",
+        "runtime.aot.system.runtime.interopservices.4.0.20.nupkg.sha512",
+        "runtime.aot.system.runtime.interopservices.nuspec",
         "runtimes/aot/lib/netcore50/System.Runtime.InteropServices.dll"
       ]
     },
     "runtime.aot.System.Text.Encoding/4.0.11": {
       "sha512": "mUltrQRF5trt9DvIDPxV5E3girWcXlJgQBnYHfy1b8RQU2Ipob6xzCqlDnnECa8+FdhD8C/A7s7krxvHWcJ/pw==",
       "type": "package",
+      "path": "runtime.aot.system.text.encoding/4.0.11",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Text.Encoding.4.0.11.nupkg.sha512",
-        "runtime.aot.System.Text.Encoding.nuspec",
+        "runtime.aot.system.text.encoding.4.0.11.nupkg.sha512",
+        "runtime.aot.system.text.encoding.nuspec",
         "runtimes/aot/lib/netcore50/System.Text.Encoding.dll"
       ]
     },
     "runtime.aot.System.Text.Encoding.Extensions/4.0.11": {
       "sha512": "N6XCU9y8ZC51LfxnE5tgNFy+3emNQTRY6W3NeLqlHLcina5vbChsSsPDOCpEIGMTOMxbODe5HtWYbzaOOSFtGg==",
       "type": "package",
+      "path": "runtime.aot.system.text.encoding.extensions/4.0.11",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Text.Encoding.Extensions.4.0.11.nupkg.sha512",
-        "runtime.aot.System.Text.Encoding.Extensions.nuspec",
+        "runtime.aot.system.text.encoding.extensions.4.0.11.nupkg.sha512",
+        "runtime.aot.system.text.encoding.extensions.nuspec",
         "runtimes/aot/lib/netcore50/System.Text.Encoding.Extensions.dll"
       ]
     },
     "runtime.aot.System.Threading.Tasks/4.0.11": {
       "sha512": "55coohhmT0Usdq536a54bqGK4ij2D1ZTaJo8lQ3k/piwVx+Dl2r3xmDGsims+jVimQVayU2tXptKSAn9nhgRfA==",
       "type": "package",
+      "path": "runtime.aot.system.threading.tasks/4.0.11",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Threading.Tasks.4.0.11.nupkg.sha512",
-        "runtime.aot.System.Threading.Tasks.nuspec",
+        "runtime.aot.system.threading.tasks.4.0.11.nupkg.sha512",
+        "runtime.aot.system.threading.tasks.nuspec",
         "runtimes/aot/lib/netcore50/System.Threading.Tasks.dll"
       ]
     },
     "runtime.aot.System.Threading.Timer/4.0.1": {
       "sha512": "c4IE4f4MBSzr3b8uSCIpqc70uXbkNJx9oAASbEMhFGdyxljpwz14xYR5hp8AgnF4msF8tPL6zgOf7lDlSo0j/g==",
       "type": "package",
+      "path": "runtime.aot.system.threading.timer/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.aot.System.Threading.Timer.4.0.1.nupkg.sha512",
-        "runtime.aot.System.Threading.Timer.nuspec",
+        "runtime.aot.system.threading.timer.4.0.1.nupkg.sha512",
+        "runtime.aot.system.threading.timer.nuspec",
         "runtimes/aot/lib/netcore50/System.Threading.Timer.dll"
       ]
     },
     "runtime.native.System.IO.Compression/4.1.0": {
-      "sha512": "Ob7nvnJBox1aaB222zSVZSkf4WrebPG4qFscfK7vmD7P7NxoSxACQLtO7ytWpqXDn2wcd/+45+EAZ7xjaPip8A==",
+      "sha512": "gN+NZ8NsTdejGyJ3GZTAWDWJ4FFKICKOLjEEvI3atx7mysxm15DnYFY+r7LU7EyixDfuXE2jKvvZdBi/Zps+pQ==",
       "type": "package",
+      "path": "runtime.native.system.io.compression/4.1.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/netstandard1.0/_._",
-        "runtime.native.System.IO.Compression.4.1.0.nupkg.sha512",
-        "runtime.native.System.IO.Compression.nuspec"
+        "runtime.native.system.io.compression.4.1.0.nupkg.sha512",
+        "runtime.native.system.io.compression.nuspec"
       ]
     },
     "runtime.native.System.Security.Cryptography/4.0.0": {
-      "sha512": "2CQK0jmO6Eu7ZeMgD+LOFbNJSXHFVQbCJJkEyEwowh1SCgYnrn9W9RykMfpeeVGw7h4IBvYikzpGUlmZTUafJw==",
+      "sha512": "xW/PzHm8wWFGuBhxVkm50ntKXaxWpNf7IFx6okqFksikvudsoGBo+kO7Zr7S4LTJOO9xMWHRtR+rci+NeIVoMw==",
       "type": "package",
+      "path": "runtime.native.system.security.cryptography/4.0.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/netstandard1.0/_._",
-        "runtime.native.System.Security.Cryptography.4.0.0.nupkg.sha512",
-        "runtime.native.System.Security.Cryptography.nuspec"
+        "runtime.native.system.security.cryptography.4.0.0.nupkg.sha512",
+        "runtime.native.system.security.cryptography.nuspec"
       ]
     },
     "runtime.win.Microsoft.Win32.Primitives/4.0.1": {
       "sha512": "0alFxXfT7M+xhhgMkNzG/Mnfii3o+DGQV9gkmhfLr6wsRPNxlIHdz4yQC8ksHqqmOu1Sq0FD9FxrSQyGo+8syA==",
       "type": "package",
+      "path": "runtime.win.microsoft.win32.primitives/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.win.Microsoft.Win32.Primitives.4.0.1.nupkg.sha512",
-        "runtime.win.Microsoft.Win32.Primitives.nuspec",
+        "runtime.win.microsoft.win32.primitives.4.0.1.nupkg.sha512",
+        "runtime.win.microsoft.win32.primitives.nuspec",
         "runtimes/win/lib/net/_._",
         "runtimes/win/lib/netstandard1.3/Microsoft.Win32.Primitives.dll"
       ]
@@ -16231,12 +17269,13 @@
     "runtime.win.System.Diagnostics.Debug/4.0.11": {
       "sha512": "q8Fm954ezFLfmG0tHNUmsNy+qaEjWtWqYhWh3cGSVjtJwkcBsfigWCh+fdaIVZ9K7m+6lgb3ElL2BBU6G+RijA==",
       "type": "package",
+      "path": "runtime.win.system.diagnostics.debug/4.0.11",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.win.System.Diagnostics.Debug.4.0.11.nupkg.sha512",
-        "runtime.win.System.Diagnostics.Debug.nuspec",
+        "runtime.win.system.diagnostics.debug.4.0.11.nupkg.sha512",
+        "runtime.win.system.diagnostics.debug.nuspec",
         "runtimes/aot/lib/netcore50/System.Diagnostics.Debug.dll",
         "runtimes/win/lib/net45/_._",
         "runtimes/win/lib/netcore50/System.Diagnostics.Debug.dll",
@@ -16249,12 +17288,13 @@
     "runtime.win.System.IO.FileSystem/4.0.1": {
       "sha512": "4FG9RK8J5CsUpXjkiZWS07aJu+H+vTIeQkFKXyjwibfBedUM168SCEaqV3Bjkbv4b3pUuf5Gy1RaqX/HnmKlZw==",
       "type": "package",
+      "path": "runtime.win.system.io.filesystem/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.win.System.IO.FileSystem.4.0.1.nupkg.sha512",
-        "runtime.win.System.IO.FileSystem.nuspec",
+        "runtime.win.system.io.filesystem.4.0.1.nupkg.sha512",
+        "runtime.win.system.io.filesystem.nuspec",
         "runtimes/win/lib/net/_._",
         "runtimes/win/lib/netcore50/System.IO.FileSystem.dll",
         "runtimes/win/lib/netstandard1.3/System.IO.FileSystem.dll",
@@ -16266,12 +17306,13 @@
     "runtime.win.System.Net.Primitives/4.0.11": {
       "sha512": "36AsEkT9p+4cLHHh7sgSIOPWWeTKMh/DOoeQCzJmaLM8rtD9YaRZMmXGynf77ZP5KoXWwA4Y3aGbntrPbmmlcA==",
       "type": "package",
+      "path": "runtime.win.system.net.primitives/4.0.11",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.win.System.Net.Primitives.4.0.11.nupkg.sha512",
-        "runtime.win.System.Net.Primitives.nuspec",
+        "runtime.win.system.net.primitives.4.0.11.nupkg.sha512",
+        "runtime.win.system.net.primitives.nuspec",
         "runtimes/win/lib/net/_._",
         "runtimes/win/lib/netcore50/System.Net.Primitives.dll",
         "runtimes/win/lib/netstandard1.3/System.Net.Primitives.dll"
@@ -16280,12 +17321,13 @@
     "runtime.win.System.Net.Sockets/4.1.0": {
       "sha512": "BviTpQJbl+T/XVkwLw5xupFq9WXKru9KM/2U/ijmLuO2XEeMgdwk3g0e9sHWqvbrLvVT9yDf+SpbRXM1LNxTvA==",
       "type": "package",
+      "path": "runtime.win.system.net.sockets/4.1.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.win.System.Net.Sockets.4.1.0.nupkg.sha512",
-        "runtime.win.System.Net.Sockets.nuspec",
+        "runtime.win.system.net.sockets.4.1.0.nupkg.sha512",
+        "runtime.win.system.net.sockets.nuspec",
         "runtimes/win/lib/net/_._",
         "runtimes/win/lib/netcore50/System.Net.Sockets.dll",
         "runtimes/win/lib/netstandard1.3/System.Net.Sockets.dll"
@@ -16294,12 +17336,13 @@
     "runtime.win.System.Runtime.Extensions/4.1.0": {
       "sha512": "U3F/M+djxVXuKJaoW2AGpAE2ZWAp372140jsX4d/ctqki+Qb61HuyQY4yUPSA/gdKGbbq6HXzZ6oxB6/G3MYPA==",
       "type": "package",
+      "path": "runtime.win.system.runtime.extensions/4.1.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.win.System.Runtime.Extensions.4.1.0.nupkg.sha512",
-        "runtime.win.System.Runtime.Extensions.nuspec",
+        "runtime.win.system.runtime.extensions.4.1.0.nupkg.sha512",
+        "runtime.win.system.runtime.extensions.nuspec",
         "runtimes/aot/lib/netcore50/System.Runtime.Extensions.dll",
         "runtimes/win/lib/net/_._",
         "runtimes/win/lib/netcore50/System.Runtime.Extensions.dll",
@@ -16309,44 +17352,48 @@
     "runtime.win10-arm-aot.runtime.native.System.IO.Compression/4.0.1": {
       "sha512": "fzsKrHHfrv6wpLE1sxAHcWoB9vpAyoNjxVTnBJkzeXow2ZivR1H7wdpnsoKXIIb0d2EzYrrezHeHy4gI6tqqTA==",
       "type": "package",
+      "path": "runtime.win10-arm-aot.runtime.native.system.io.compression/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
-        "runtime.win10-arm-aot.runtime.native.System.IO.Compression.4.0.1.nupkg.sha512",
-        "runtime.win10-arm-aot.runtime.native.System.IO.Compression.nuspec",
+        "runtime.win10-arm-aot.runtime.native.system.io.compression.4.0.1.nupkg.sha512",
+        "runtime.win10-arm-aot.runtime.native.system.io.compression.nuspec",
         "runtimes/win10-arm-aot/lib/netcore50/clrcompression.dll"
       ]
     },
     "runtime.win10-x64-aot.runtime.native.System.IO.Compression/4.0.1": {
       "sha512": "qr2+iGSxqUjVW3eATYzV4GHN6qQOu5cDTzCGf7VZ4aaxXGv2P/XVk9BkQ6WdPCDitEdIuWmtFYIFvGdvY/qN6Q==",
       "type": "package",
+      "path": "runtime.win10-x64-aot.runtime.native.system.io.compression/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
-        "runtime.win10-x64-aot.runtime.native.System.IO.Compression.4.0.1.nupkg.sha512",
-        "runtime.win10-x64-aot.runtime.native.System.IO.Compression.nuspec",
+        "runtime.win10-x64-aot.runtime.native.system.io.compression.4.0.1.nupkg.sha512",
+        "runtime.win10-x64-aot.runtime.native.system.io.compression.nuspec",
         "runtimes/win10-x64-aot/lib/netcore50/clrcompression.dll"
       ]
     },
     "runtime.win10-x86-aot.runtime.native.System.IO.Compression/4.0.1": {
       "sha512": "c3yeCSi1emskJMjeqbX6B+neZRozhYk4et/Lv/6s05Yz30jcwY2Mj5PAr7mvmlAZtP5+HLbxz+Ux+RNNM/1GUA==",
       "type": "package",
+      "path": "runtime.win10-x86-aot.runtime.native.system.io.compression/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
-        "runtime.win10-x86-aot.runtime.native.System.IO.Compression.4.0.1.nupkg.sha512",
-        "runtime.win10-x86-aot.runtime.native.System.IO.Compression.nuspec",
+        "runtime.win10-x86-aot.runtime.native.system.io.compression.4.0.1.nupkg.sha512",
+        "runtime.win10-x86-aot.runtime.native.system.io.compression.nuspec",
         "runtimes/win10-x86-aot/lib/netcore50/clrcompression.dll"
       ]
     },
     "runtime.win7-x64.Microsoft.NETCore.Jit/1.0.3": {
       "sha512": "pXLZyhN1gFNVjmmZloXzGxbdZyUjkiHKpojzxUxCZ2U+T0jD6ooK3rYhwqFzlSjVKUAdQ9QNDoixxnEr3/5VWw==",
       "type": "package",
+      "path": "runtime.win7-x64.microsoft.netcore.jit/1.0.3",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
-        "runtime.win7-x64.Microsoft.NETCore.Jit.1.0.3.nupkg.sha512",
-        "runtime.win7-x64.Microsoft.NETCore.Jit.nuspec",
+        "runtime.win7-x64.microsoft.netcore.jit.1.0.3.nupkg.sha512",
+        "runtime.win7-x64.microsoft.netcore.jit.nuspec",
         "runtimes/win7-x64-aot/native/_._",
         "runtimes/win7-x64/native/clrjit.dll"
       ]
@@ -16354,12 +17401,13 @@
     "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.2": {
       "sha512": "YaXA5RVLCYIcV1N31A7MJhWJnNkNfGnyRBNH1yYilUrBDvzMxNsbXX2pD7owWsC/go/4LRwbHbdWWXwHowKNvw==",
       "type": "package",
+      "path": "runtime.win7-x64.microsoft.netcore.runtime.coreclr/1.0.2",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard1.0/_._",
-        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.2.nupkg.sha512",
-        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
+        "runtime.win7-x64.microsoft.netcore.runtime.coreclr.1.0.2.nupkg.sha512",
+        "runtime.win7-x64.microsoft.netcore.runtime.coreclr.nuspec",
         "runtimes/win7-x64-aot/lib/netstandard1.0/_._",
         "runtimes/win7-x64-aot/native/_._",
         "runtimes/win7-x64/lib/netstandard1.0/System.Private.CoreLib.dll",
@@ -16380,22 +17428,24 @@
     "runtime.win7-x64.runtime.native.System.IO.Compression/4.0.1": {
       "sha512": "4LLiT65shsAsGc+mUKV3vUw1SXfOaQWGWoblOYpYuZJSVkA3/LPx92M2GSYyn2sHR/XOFtY5TZmxJKgGlZOLFw==",
       "type": "package",
+      "path": "runtime.win7-x64.runtime.native.system.io.compression/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
-        "runtime.win7-x64.runtime.native.System.IO.Compression.4.0.1.nupkg.sha512",
-        "runtime.win7-x64.runtime.native.System.IO.Compression.nuspec",
+        "runtime.win7-x64.runtime.native.system.io.compression.4.0.1.nupkg.sha512",
+        "runtime.win7-x64.runtime.native.system.io.compression.nuspec",
         "runtimes/win7-x64/native/clrcompression.dll"
       ]
     },
     "runtime.win7-x86.Microsoft.NETCore.Jit/1.0.3": {
       "sha512": "bU1EUneMeB6JltMNDCekL7nP1dluxOlnUgmAFx8EGsD6a+lgaYoDLk7V7F3H5Zpw/LeCxl5XmZqgPObGAlW7Dg==",
       "type": "package",
+      "path": "runtime.win7-x86.microsoft.netcore.jit/1.0.3",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
-        "runtime.win7-x86.Microsoft.NETCore.Jit.1.0.3.nupkg.sha512",
-        "runtime.win7-x86.Microsoft.NETCore.Jit.nuspec",
+        "runtime.win7-x86.microsoft.netcore.jit.1.0.3.nupkg.sha512",
+        "runtime.win7-x86.microsoft.netcore.jit.nuspec",
         "runtimes/win7-x86-aot/native/_._",
         "runtimes/win7-x86/native/clrjit.dll"
       ]
@@ -16403,12 +17453,13 @@
     "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.2": {
       "sha512": "80Jj8QlMLAnTq+BDhoHBnSNXRKqVjjZM9VjHcpw9/F98cBmh80rBdbnM0AAr54htjhzupYvwLqwuKnlzxec04A==",
       "type": "package",
+      "path": "runtime.win7-x86.microsoft.netcore.runtime.coreclr/1.0.2",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard1.0/_._",
-        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.1.0.2.nupkg.sha512",
-        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
+        "runtime.win7-x86.microsoft.netcore.runtime.coreclr.1.0.2.nupkg.sha512",
+        "runtime.win7-x86.microsoft.netcore.runtime.coreclr.nuspec",
         "runtimes/win7-x86-aot/lib/netstandard1.0/_._",
         "runtimes/win7-x86-aot/native/_._",
         "runtimes/win7-x86/lib/netstandard1.0/System.Private.CoreLib.dll",
@@ -16429,23 +17480,25 @@
     "runtime.win7-x86.runtime.native.System.IO.Compression/4.0.1": {
       "sha512": "3jgpS2GhE76QqeoTxCakx6jlX7EIeXvxHnFFDa03Jf++s9+EGnRD38R6GDb1ism73xo6IHe0iev7zd5y+oD3BA==",
       "type": "package",
+      "path": "runtime.win7-x86.runtime.native.system.io.compression/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
-        "runtime.win7-x86.runtime.native.System.IO.Compression.4.0.1.nupkg.sha512",
-        "runtime.win7-x86.runtime.native.System.IO.Compression.nuspec",
+        "runtime.win7-x86.runtime.native.system.io.compression.4.0.1.nupkg.sha512",
+        "runtime.win7-x86.runtime.native.system.io.compression.nuspec",
         "runtimes/win7-x86/native/clrcompression.dll"
       ]
     },
     "runtime.win7.System.Private.Uri/4.0.2": {
       "sha512": "N0nsmkEe+e3fl28KZ9LrHQ06XvhTC4FGyWacInV90h3pmty2s0fnG0GZ41rQw8d51s+pLcTQ0dKS0eN0xESY7g==",
       "type": "package",
+      "path": "runtime.win7.system.private.uri/4.0.2",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
-        "runtime.win7.System.Private.Uri.4.0.2.nupkg.sha512",
-        "runtime.win7.System.Private.Uri.nuspec",
+        "runtime.win7.system.private.uri.4.0.2.nupkg.sha512",
+        "runtime.win7.system.private.uri.nuspec",
         "runtimes/aot/lib/netcore50/System.Private.Uri.dll",
         "runtimes/win/lib/netcore50/System.Private.Uri.dll",
         "runtimes/win/lib/netstandard1.0/System.Private.Uri.dll"
@@ -16454,12 +17507,13 @@
     "runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR/1.0.2": {
       "sha512": "0V6sq7Dg0bQPrJtm/Qw5Zu0e7gidnRPLaqUhKIkLYzVn64jkat+JnR6LcezryD3c0Wuva/MdJWYSAaOPq5V/Zw==",
       "type": "package",
+      "path": "runtime.win8-arm.microsoft.netcore.runtime.coreclr/1.0.2",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard1.0/_._",
-        "runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR.1.0.2.nupkg.sha512",
-        "runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
+        "runtime.win8-arm.microsoft.netcore.runtime.coreclr.1.0.2.nupkg.sha512",
+        "runtime.win8-arm.microsoft.netcore.runtime.coreclr.nuspec",
         "runtimes/win8-arm-aot/lib/netstandard1.0/_._",
         "runtimes/win8-arm-aot/native/_._",
         "runtimes/win8-arm/lib/netstandard1.0/System.Private.CoreLib.dll",
@@ -16481,20 +17535,20 @@
     "runtime.win8-arm.runtime.native.System.IO.Compression/4.0.1": {
       "sha512": "EwyUwoJJLeSqfmeZoX9nxKx8Q9pEwX5zLLgSwtdH04+TzUYxaDIaoNqH5hfhoaSl2VoDsHGbEnQ6Y5bXLcWSkA==",
       "type": "package",
+      "path": "runtime.win8-arm.runtime.native.system.io.compression/4.0.1",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
-        "runtime.win8-arm.runtime.native.System.IO.Compression.4.0.1.nupkg.sha512",
-        "runtime.win8-arm.runtime.native.System.IO.Compression.nuspec",
+        "runtime.win8-arm.runtime.native.system.io.compression.4.0.1.nupkg.sha512",
+        "runtime.win8-arm.runtime.native.system.io.compression.nuspec",
         "runtimes/win8-arm/native/clrcompression.dll"
       ]
     },
     "System.AppContext/4.1.0": {
-      "sha512": "3QjO4jNV7PdKkmQAVp9atA+usVnKRwI3Kx1nMwJ93T0LcQfx7pKAYk0nKz5wn1oP5iqlhZuy6RXOFdhr7rDwow==",
+      "sha512": "rtrIACXb9ADafOvG5WaM9KRX5FDh27wHwDLpFoRpb44HZHCpSuNt5Fpl1x3fZ5jzCULyQrUIUJslExLTI5t58A==",
       "type": "package",
+      "path": "system.appcontext/4.1.0",
       "files": [
-        "System.AppContext.4.1.0.nupkg.sha512",
-        "System.AppContext.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -16538,27 +17592,29 @@
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
-        "runtimes/aot/lib/netcore50/System.AppContext.dll"
+        "runtimes/aot/lib/netcore50/System.AppContext.dll",
+        "system.appcontext.4.1.0.nupkg.sha512",
+        "system.appcontext.nuspec"
       ]
     },
     "System.Buffers/4.0.0": {
-      "sha512": "msXumHfjjURSkvxUjYuq4N2ghHoRi2VpXcKMA7gK6ujQfU3vGpl+B6ld0ATRg+FZFpRyA6PgEPA+VlIkTeNf2w==",
+      "sha512": "cSfyYKpq9oGQLZVYZ4J3BNSA3VYh2balEDqxBuPQ9HXIsb0zidkOVoJ34HK3TMPYeHmKIgJtYm6tAiiNiHjPxg==",
       "type": "package",
+      "path": "system.buffers/4.0.0",
       "files": [
-        "System.Buffers.4.0.0.nupkg.sha512",
-        "System.Buffers.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/netstandard1.1/.xml",
-        "lib/netstandard1.1/System.Buffers.dll"
+        "lib/netstandard1.1/System.Buffers.dll",
+        "system.buffers.4.0.0.nupkg.sha512",
+        "system.buffers.nuspec"
       ]
     },
     "System.Collections/4.0.11": {
-      "sha512": "YUJGz6eFKqS0V//mLt25vFGrrCvOnsXjlvFQs+KimpwNxug9x0Pzy4PlFMU3Q2IzqAa9G2L4LsK3+9vCBK7oTg==",
+      "sha512": "Y5xVDnj5ojwlel3fz3pYFAxZtXSPyp555WXRbJC3+UvGuWAHJ4lPqRxbDEsF8w5xeM2JGH1UhpHmkgBdSjZqfw==",
       "type": "package",
+      "path": "system.collections/4.0.11",
       "files": [
-        "System.Collections.4.0.11.nupkg.sha512",
-        "System.Collections.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -16615,15 +17671,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.collections.4.0.11.nupkg.sha512",
+        "system.collections.nuspec"
       ]
     },
     "System.Collections.Concurrent/4.0.12": {
-      "sha512": "2gBcbb3drMLgxlI0fBfxMA31ec6AEyYCHygGse4vxceJan8mRIWeKJ24BFzN7+bi/NFTgdIgufzb94LWO5EERQ==",
+      "sha512": "rL0bXvyEwFLCUOsR5PPzvNqZ37cxSZ0iqqKtsYH3bUbPvTYi88NOAggdIcGuDq++2ANgHuSousXvOL9Mrr3cgw==",
       "type": "package",
+      "path": "system.collections.concurrent/4.0.12",
       "files": [
-        "System.Collections.Concurrent.4.0.12.nupkg.sha512",
-        "System.Collections.Concurrent.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -16680,29 +17737,31 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.collections.concurrent.4.0.12.nupkg.sha512",
+        "system.collections.concurrent.nuspec"
       ]
     },
     "System.Collections.Immutable/1.2.0": {
-      "sha512": "Cma8cBW6di16ZLibL8LYQ+cLjGzoKxpOTu/faZfDcx94ZjAGq6Nv5RO7+T1YZXqEXTZP9rt1wLVEONVpURtUqw==",
+      "sha512": "awAUV1LWfAdu192Qc1lQgPAyr2+bWFJylClqF0SAjRdgoSt51iF1ENA+YhnkIZRVXYs2WN8neWYHDVMpDYh1GA==",
       "type": "package",
+      "path": "system.collections.immutable/1.2.0",
       "files": [
-        "System.Collections.Immutable.1.2.0.nupkg.sha512",
-        "System.Collections.Immutable.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/netstandard1.0/System.Collections.Immutable.dll",
         "lib/netstandard1.0/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml"
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "system.collections.immutable.1.2.0.nupkg.sha512",
+        "system.collections.immutable.nuspec"
       ]
     },
     "System.Collections.NonGeneric/4.0.1": {
-      "sha512": "hMxFT2RhhlffyCdKLDXjx8WEC5JfCvNozAZxCablAuFRH74SCV4AgzE8yJCh/73bFnEoZgJ9MJmkjQ0dJmnKqA==",
+      "sha512": "rfIfsLnN6pE9JOsSdOvSwDZgdyA8dForYYhXxb7N2AREgHk1q3k9Vu3EIZb2A/fpBIJ8HqoB1tUKue7IkwWr9Q==",
       "type": "package",
+      "path": "system.collections.nongeneric/4.0.1",
       "files": [
-        "System.Collections.NonGeneric.4.0.1.nupkg.sha512",
-        "System.Collections.NonGeneric.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -16730,15 +17789,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.collections.nongeneric.4.0.1.nupkg.sha512",
+        "system.collections.nongeneric.nuspec"
       ]
     },
     "System.Collections.Specialized/4.0.1": {
-      "sha512": "/HKQyVP0yH1I0YtK7KJL/28snxHNH/bi+0lgk/+MbURF6ULhAE31MDI+NZDerNWu264YbxklXCCygISgm+HMug==",
+      "sha512": "Gg+SOA27kd62gkpO5z20qDGiZaz2MMkraDLv4e2fJ8ictIuhCfZo1bOcG174ReEpjHJt61YIy9pf8DlawKljMg==",
       "type": "package",
+      "path": "system.collections.specialized/4.0.1",
       "files": [
-        "System.Collections.Specialized.4.0.1.nupkg.sha512",
-        "System.Collections.Specialized.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -16766,15 +17826,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.collections.specialized.4.0.1.nupkg.sha512",
+        "system.collections.specialized.nuspec"
       ]
     },
     "System.ComponentModel/4.0.1": {
-      "sha512": "oBZFnm7seFiVfugsIyOvQCWobNZs7FzqDV/B7tx20Ep/l3UUFCPDkdTnCNaJZTU27zjeODmy2C/cP60u3D4c9w==",
+      "sha512": "NY7bE78j8yeO2Md+CM5IeydEBGy62vCm/xMXCuUCGieQ/xwsWZY4yP2nv/v+3kwZfGlpw5U2kjh9ed4XZpjp7Q==",
       "type": "package",
+      "path": "system.componentmodel/4.0.1",
       "files": [
-        "System.ComponentModel.4.0.1.nupkg.sha512",
-        "System.ComponentModel.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -16822,15 +17883,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.componentmodel.4.0.1.nupkg.sha512",
+        "system.componentmodel.nuspec"
       ]
     },
     "System.ComponentModel.Annotations/4.1.0": {
-      "sha512": "rhnz80h8NnHJzoi0nbQJLRR2cJznyqG168q1bgoSpe5qpaME2SguXzuEzpY68nFCi2kBgHpbU4bRN2cP3unYRA==",
+      "sha512": "JTMgq1X6HmBbxdqSsDKWcpFxePQpXGQaaBX+2VqWd3CPRZ/qFWTHEyXfyspsIbRlXFlieMyiSOs3KZBnQfWewg==",
       "type": "package",
+      "path": "system.componentmodel.annotations/4.1.0",
       "files": [
-        "System.ComponentModel.Annotations.4.1.0.nupkg.sha512",
-        "System.ComponentModel.Annotations.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -16898,15 +17960,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.componentmodel.annotations.4.1.0.nupkg.sha512",
+        "system.componentmodel.annotations.nuspec"
       ]
     },
     "System.ComponentModel.EventBasedAsync/4.0.11": {
       "sha512": "Z7SO6vvQIR84daPE4uhaNdef9CjgjDMGYkas8epUhf0U3WGuaGgZ0Mm4QuNycMdbHUY8KEdZrtgxonkAiJaAlA==",
       "type": "package",
+      "path": "system.componentmodel.eventbasedasync/4.0.11",
       "files": [
-        "System.ComponentModel.EventBasedAsync.4.0.11.nupkg.sha512",
-        "System.ComponentModel.EventBasedAsync.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -16965,15 +18028,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.componentmodel.eventbasedasync.4.0.11.nupkg.sha512",
+        "system.componentmodel.eventbasedasync.nuspec"
       ]
     },
     "System.Data.Common/4.1.0": {
-      "sha512": "epU8jeTe7aE7RqGHq9rZ8b0Q4Ah7DgubzHQblgZMSqgW1saW868WmooSyC5ywf8upLBkcVLDu93W9GPWUYsU2Q==",
+      "sha512": "oJDqO0YdZ8xZ7eNu4REBj5Eg3VgHll1UKKbTPESq6M2th1yKQ1dDeIPHzxOKxZTHSgu4urpFDviK77hR24mGtg==",
       "type": "package",
+      "path": "system.data.common/4.1.0",
       "files": [
-        "System.Data.Common.4.1.0.nupkg.sha512",
-        "System.Data.Common.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17013,15 +18077,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.data.common.4.1.0.nupkg.sha512",
+        "system.data.common.nuspec"
       ]
     },
     "System.Diagnostics.Contracts/4.0.1": {
-      "sha512": "HvQQjy712vnlpPxaloZYkuE78Gn353L0SJLJVeLcNASeg9c4qla2a1Xq8I7B3jZoDzKPtHTkyVO7AZ5tpeQGuA==",
+      "sha512": "pOAnBnABau0Yr2YI+KAwWY2quWUzGZbsskRNcFFzZV/UNw7EhdhlGRykzx2B6EKfCMT20IAqWwEOt7kax1OBfA==",
       "type": "package",
+      "path": "system.diagnostics.contracts/4.0.1",
       "files": [
-        "System.Diagnostics.Contracts.4.0.1.nupkg.sha512",
-        "System.Diagnostics.Contracts.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17070,15 +18135,16 @@
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
-        "runtimes/aot/lib/netcore50/System.Diagnostics.Contracts.dll"
+        "runtimes/aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "system.diagnostics.contracts.4.0.1.nupkg.sha512",
+        "system.diagnostics.contracts.nuspec"
       ]
     },
     "System.Diagnostics.Debug/4.0.11": {
-      "sha512": "w5U95fVKHY4G8ASs/K5iK3J5LY+/dLFd4vKejsnI/ZhBsWS9hQakfx3Zr7lRWKg4tAw9r4iktyvsTagWkqYCiw==",
+      "sha512": "D2GS6gz99Eea37uT8jxXrGv40WLvhigspEjRteXSKu4D6hf1vS/sbYPvqXBiA3SJICZB7u7ejggZLrPfazf6Sw==",
       "type": "package",
+      "path": "system.diagnostics.debug/4.0.11",
       "files": [
-        "System.Diagnostics.Debug.4.0.11.nupkg.sha512",
-        "System.Diagnostics.Debug.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17135,15 +18201,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.diagnostics.debug.4.0.11.nupkg.sha512",
+        "system.diagnostics.debug.nuspec"
       ]
     },
     "System.Diagnostics.DiagnosticSource/4.0.0": {
-      "sha512": "YKglnq4BMTJxfcr6nuT08g+yJ0UxdePIHxosiLuljuHIUR6t4KhFsyaHOaOc1Ofqp0PUvJ0EmcgiEz6T7vEx3w==",
+      "sha512": "oOex3VXfi4far34sNGw14/woqjAJoNhT+zNBwk8VRAKOinM6qqy8KjQAVYTGBCnmA93Hyru3/yc0e3mCs/429g==",
       "type": "package",
+      "path": "system.diagnostics.diagnosticsource/4.0.0",
       "files": [
-        "System.Diagnostics.DiagnosticSource.4.0.0.nupkg.sha512",
-        "System.Diagnostics.DiagnosticSource.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/net46/System.Diagnostics.DiagnosticSource.dll",
@@ -17153,15 +18220,16 @@
         "lib/netstandard1.3/System.Diagnostics.DiagnosticSource.dll",
         "lib/netstandard1.3/System.Diagnostics.DiagnosticSource.xml",
         "lib/portable-net45+win8+wpa81/System.Diagnostics.DiagnosticSource.dll",
-        "lib/portable-net45+win8+wpa81/System.Diagnostics.DiagnosticSource.xml"
+        "lib/portable-net45+win8+wpa81/System.Diagnostics.DiagnosticSource.xml",
+        "system.diagnostics.diagnosticsource.4.0.0.nupkg.sha512",
+        "system.diagnostics.diagnosticsource.nuspec"
       ]
     },
     "System.Diagnostics.StackTrace/4.0.2": {
       "sha512": "MmP424iVWLyeW7XGtwC5NyfzsIwodFKwhW6yns3d+Sh8WFsFoPWq2cUlJJDAteapIm2qoJ8fc3VwIUroolbsEA==",
       "type": "package",
+      "path": "system.diagnostics.stacktrace/4.0.2",
       "files": [
-        "System.Diagnostics.StackTrace.4.0.2.nupkg.sha512",
-        "System.Diagnostics.StackTrace.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17190,15 +18258,16 @@
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
-        "runtimes/aot/lib/netcore50/System.Diagnostics.StackTrace.dll"
+        "runtimes/aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "system.diagnostics.stacktrace.4.0.2.nupkg.sha512",
+        "system.diagnostics.stacktrace.nuspec"
       ]
     },
     "System.Diagnostics.Tools/4.0.1": {
-      "sha512": "xBfJ8pnd4C17dWaC9FM6aShzbJcRNMChUMD42I6772KGGrqaFdumwhn9OdM68erj1ueNo3xdQ1EwiFjK5k8p0g==",
+      "sha512": "KVoOfaRfLVsTTPGl2AVNglMrKg062RuUy0dR8GJ83wGFXWUIOVYZBDRAtFidqch+ZDcH/GZdKu8kADqRxmwP6Q==",
       "type": "package",
+      "path": "system.diagnostics.tools/4.0.1",
       "files": [
-        "System.Diagnostics.Tools.4.0.1.nupkg.sha512",
-        "System.Diagnostics.Tools.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17244,15 +18313,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.diagnostics.tools.4.0.1.nupkg.sha512",
+        "system.diagnostics.tools.nuspec"
       ]
     },
     "System.Diagnostics.Tracing/4.1.0": {
-      "sha512": "vDN1PoMZCkkdNjvZLql592oYJZgS7URcJzJ7bxeBgGtx5UtR5leNm49VmfHGqIffX4FKacHbI3H6UyNSHQknBg==",
+      "sha512": "KGx/878ZGXn4VS2fY7RIBth/BBWoJTgeimsnoNibo5742QUJ/lmfFa7CZjy2qMIp2APQ52UlnPo3P59apw0zww==",
       "type": "package",
+      "path": "system.diagnostics.tracing/4.1.0",
       "files": [
-        "System.Diagnostics.Tracing.4.1.0.nupkg.sha512",
-        "System.Diagnostics.Tracing.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17331,15 +18401,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.diagnostics.tracing.4.1.0.nupkg.sha512",
+        "system.diagnostics.tracing.nuspec"
       ]
     },
     "System.Dynamic.Runtime/4.0.11": {
-      "sha512": "db34f6LHYM0U0JpE+sOmjar27BnqTVkbLJhgfwMpTdgTigG/Hna3m2MYVwnFzGGKnEJk2UXFuoVTr8WUbU91/A==",
+      "sha512": "PwN/zC9uttGsp9Sz5BA5UYu/sT8xQqMfDE+tf1guM0ULEH/EIGIawuF585nx9v68FQlMjhWHgXtKbPk3pK7Mkw==",
       "type": "package",
+      "path": "system.dynamic.runtime/4.0.11",
       "files": [
-        "System.Dynamic.Runtime.4.0.11.nupkg.sha512",
-        "System.Dynamic.Runtime.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17399,15 +18470,16 @@
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
-        "runtimes/aot/lib/netcore50/System.Dynamic.Runtime.dll"
+        "runtimes/aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "system.dynamic.runtime.4.0.11.nupkg.sha512",
+        "system.dynamic.runtime.nuspec"
       ]
     },
     "System.Globalization/4.0.11": {
-      "sha512": "B95h0YLEL2oSnwF/XjqSWKnwKOy/01VWkNlsCeMTFJLLabflpGV26nK164eRs5GiaRSBGpOxQ3pKoSnnyZN5pg==",
+      "sha512": "sKoH+W3Lvd7U1hvXmGaTIW1qhGQskQuJOX0t+1wSFjapLE5DjvXDYcKMZZ8MC97mhoIQXvGof8k0cbrLrZPVWg==",
       "type": "package",
+      "path": "system.globalization/4.0.11",
       "files": [
-        "System.Globalization.4.0.11.nupkg.sha512",
-        "System.Globalization.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17464,15 +18536,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.globalization.4.0.11.nupkg.sha512",
+        "system.globalization.nuspec"
       ]
     },
     "System.Globalization.Calendars/4.0.1": {
-      "sha512": "L1c6IqeQ88vuzC1P81JeHmHA8mxq8a18NUBNXnIY/BVb+TCyAaGIFbhpZt60h9FJNmisymoQkHEFSE9Vslja1Q==",
+      "sha512": "0bCE1+ysAqQz9I181vcugVEu/TqENHxm7hIkaEbWOjzsPh3/vJ5IMo+1eiNCmTcb9IaiZcCareEC6MSfUQFsQA==",
       "type": "package",
+      "path": "system.globalization.calendars/4.0.1",
       "files": [
-        "System.Globalization.Calendars.4.0.1.nupkg.sha512",
-        "System.Globalization.Calendars.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17499,15 +18572,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.globalization.calendars.4.0.1.nupkg.sha512",
+        "system.globalization.calendars.nuspec"
       ]
     },
     "System.Globalization.Extensions/4.0.1": {
-      "sha512": "KKo23iKeOaIg61SSXwjANN7QYDr/3op3OWGGzDzz7mypx0Za0fZSeG0l6cco8Ntp8YMYkIQcAqlk8yhm5/Uhcg==",
+      "sha512": "6v1xbfM18iDRd3gfyHQhiootCHsEKHNvLd443jLuSJODbxvl0OHXbw2Rg1+5M3ShZ/v5fL/3fG6Pnrvk9dA2vw==",
       "type": "package",
+      "path": "system.globalization.extensions/4.0.1",
       "files": [
-        "System.Globalization.Extensions.4.0.1.nupkg.sha512",
-        "System.Globalization.Extensions.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17537,15 +18611,16 @@
         "ref/xamarinwatchos10/_._",
         "runtimes/unix/lib/netstandard1.3/System.Globalization.Extensions.dll",
         "runtimes/win/lib/net46/System.Globalization.Extensions.dll",
-        "runtimes/win/lib/netstandard1.3/System.Globalization.Extensions.dll"
+        "runtimes/win/lib/netstandard1.3/System.Globalization.Extensions.dll",
+        "system.globalization.extensions.4.0.1.nupkg.sha512",
+        "system.globalization.extensions.nuspec"
       ]
     },
     "System.IO/4.1.0": {
-      "sha512": "3KlTJceQc3gnGIaHZ7UBZO26SHL1SHE4ddrmiwumFnId+CEHP+O8r386tZKaE6zlk5/mF8vifMBzHj9SaXN+mQ==",
+      "sha512": "ZAnKV214cEon+v+ylV7btUNLWsLLaNjI2YGTL9fTvrEtp3pSFaI8TG3mwZonaUbgpBet7ga1OEtAn+S75b3+MA==",
       "type": "package",
+      "path": "system.io/4.1.0",
       "files": [
-        "System.IO.4.1.0.nupkg.sha512",
-        "System.IO.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17615,15 +18690,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.io.4.1.0.nupkg.sha512",
+        "system.io.nuspec"
       ]
     },
     "System.IO.Compression/4.1.1": {
       "sha512": "ac/GG9DNsUr/grHGstCtWDoglgWr1OhL/yAZjXfpXtx52RmVVCpO52pShIDilQrD9dDZxw8zluiXEfezhPaYzg==",
       "type": "package",
+      "path": "system.io.compression/4.1.1",
       "files": [
-        "System.IO.Compression.4.1.1.nupkg.sha512",
-        "System.IO.Compression.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17683,15 +18759,16 @@
         "ref/xamarinwatchos10/_._",
         "runtimes/unix/lib/netstandard1.3/System.IO.Compression.dll",
         "runtimes/win/lib/net46/System.IO.Compression.dll",
-        "runtimes/win/lib/netstandard1.3/System.IO.Compression.dll"
+        "runtimes/win/lib/netstandard1.3/System.IO.Compression.dll",
+        "system.io.compression.4.1.1.nupkg.sha512",
+        "system.io.compression.nuspec"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.1": {
-      "sha512": "hBQYJzfTbQURF10nLhd+az2NHxsU6MU7AB8RUf4IolBP5lOAm4Luho851xl+CqslmhI5ZH/el8BlngEk4lBkaQ==",
+      "sha512": "IN2cHZgom+Nu/94fx720FodhCy9gMANwPTZ/8URTXdkSIoWud9p+bWMcCMo8ygBVC9K00av/jN+/SYt9LtnCFA==",
       "type": "package",
+      "path": "system.io.compression.zipfile/4.0.1",
       "files": [
-        "System.IO.Compression.ZipFile.4.0.1.nupkg.sha512",
-        "System.IO.Compression.ZipFile.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17719,15 +18796,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.io.compression.zipfile.4.0.1.nupkg.sha512",
+        "system.io.compression.zipfile.nuspec"
       ]
     },
     "System.IO.FileSystem/4.0.1": {
-      "sha512": "IBErlVq5jOggAD69bg1t0pJcHaDbJbWNUZTPI96fkYWzwYbN6D9wRHMULLDd9dHsl7C2YsxXL31LMfPI1SWt8w==",
+      "sha512": "E0V9jdoVwSHIgQNxxYCWu8Ofl4onQ/6FVYSOotsrWokrsXeFnBHqMW+OXwXuTICgs7/fwI1IDDdzSQwrSco53Q==",
       "type": "package",
+      "path": "system.io.filesystem/4.0.1",
       "files": [
-        "System.IO.FileSystem.4.0.1.nupkg.sha512",
-        "System.IO.FileSystem.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17754,15 +18832,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.io.filesystem.4.0.1.nupkg.sha512",
+        "system.io.filesystem.nuspec"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.1": {
-      "sha512": "kWkKD203JJKxJeE74p8aF8y4Qc9r9WQx4C0cHzHPrY3fv/L/IhWnyCHaFJ3H1QPOH6A93whlQ2vG5nHlBDvzWQ==",
+      "sha512": "yyzLSJm7CrSo9a3J/rFlnNUE8vrgSIvnypPCv9uWttUWh+5xdKQYpb5cfxRENegq+eDLSx6d/O1/tfOSIlVQEA==",
       "type": "package",
+      "path": "system.io.filesystem.primitives/4.0.1",
       "files": [
-        "System.IO.FileSystem.Primitives.4.0.1.nupkg.sha512",
-        "System.IO.FileSystem.Primitives.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17790,15 +18869,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.io.filesystem.primitives.4.0.1.nupkg.sha512",
+        "system.io.filesystem.primitives.nuspec"
       ]
     },
     "System.IO.IsolatedStorage/4.0.1": {
       "sha512": "PuSuDi3FV84wh6RbF+Dvr0BvLJ6MCpvNIdVE3K0sSnOVKEV7mOQ0qnEvO1tWjxquMaugULTxJHHLaxkCHCz4IQ==",
       "type": "package",
+      "path": "system.io.isolatedstorage/4.0.1",
       "files": [
-        "System.IO.IsolatedStorage.4.0.1.nupkg.sha512",
-        "System.IO.IsolatedStorage.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17824,15 +18904,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.io.isolatedstorage.4.0.1.nupkg.sha512",
+        "system.io.isolatedstorage.nuspec"
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.1": {
-      "sha512": "wcq0kXcpfJwdl1Y4/ZjDk7Dhx5HdLyRYYWYmD8Nn8skoGYYQd2BQWbXwjWSczip8AL4Z57o2dWWXAl4aABAKiQ==",
+      "sha512": "5HOt/pk4CUj3PH+w6TAvKQNMLgoeg1VtmdUWWz0Y19s8/l+eggate+ydsm1SMcC5x0WRRZxneVy5J5SLyVFomg==",
       "type": "package",
+      "path": "system.io.unmanagedmemorystream/4.0.1",
       "files": [
-        "System.IO.UnmanagedMemoryStream.4.0.1.nupkg.sha512",
-        "System.IO.UnmanagedMemoryStream.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17860,15 +18941,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.io.unmanagedmemorystream.4.0.1.nupkg.sha512",
+        "system.io.unmanagedmemorystream.nuspec"
       ]
     },
     "System.Linq/4.1.0": {
-      "sha512": "bQ0iYFOQI0nuTnt+NQADns6ucV4DUvMdwN6CbkB1yj8i7arTGiTN5eok1kQwdnnNWSDZfIUySQY+J3d5KjWn0g==",
+      "sha512": "Za2NdoXiq9cacoUvJl5FAlUw/m3U0DtFI51twtxJCmiYVCD7WJGXhFGsg3gTCoeejSLGFlLZtPxUJrgKE8x/4Q==",
       "type": "package",
+      "path": "system.linq/4.1.0",
       "files": [
-        "System.Linq.4.1.0.nupkg.sha512",
-        "System.Linq.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -17929,15 +19011,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.linq.4.1.0.nupkg.sha512",
+        "system.linq.nuspec"
       ]
     },
     "System.Linq.Expressions/4.1.0": {
-      "sha512": "I+y02iqkgmCAyfbqOmSDOgqdZQ5tTj80Akm5BPSS8EeB0VGWdy6X1KCoYe8Pk6pwDoAKZUOdLVxnTJcExiv5zw==",
+      "sha512": "QyMuTdhTpghkh9uRiWd0yQHoRzqrH2J7ST9Aidu9QhZBH4R4vHwBrBE++2R/kSrf6pfExgaovwiBGQsh4OisWA==",
       "type": "package",
+      "path": "system.linq.expressions/4.1.0",
       "files": [
-        "System.Linq.Expressions.4.1.0.nupkg.sha512",
-        "System.Linq.Expressions.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18010,15 +19093,16 @@
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
-        "runtimes/aot/lib/netcore50/System.Linq.Expressions.dll"
+        "runtimes/aot/lib/netcore50/System.Linq.Expressions.dll",
+        "system.linq.expressions.4.1.0.nupkg.sha512",
+        "system.linq.expressions.nuspec"
       ]
     },
     "System.Linq.Parallel/4.0.1": {
-      "sha512": "J7XCa7n2cFn32uLbtceXfBFhgCk5M++50lylHKNbqTiJkw5y4Tglpi6amuJNPCvj9bLzNSI7rs1fi4joLMNRgg==",
+      "sha512": "lJAd4QNsBvlEODoSD3Mc9kd7lWxSoa6i+vdLFQJfeRj3edqbdDACN4XMsMu/01okh9+hyZa5V6PgRosWggQ6aw==",
       "type": "package",
+      "path": "system.linq.parallel/4.0.1",
       "files": [
-        "System.Linq.Parallel.4.0.1.nupkg.sha512",
-        "System.Linq.Parallel.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18064,15 +19148,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.linq.parallel.4.0.1.nupkg.sha512",
+        "system.linq.parallel.nuspec"
       ]
     },
     "System.Linq.Queryable/4.0.1": {
-      "sha512": "Yn/WfYe9RoRfmSLvUt2JerP0BTGGykCZkQPgojaxgzF2N0oPo+/AhB8TXOpdCcNlrG3VRtsamtK2uzsp3cqRVw==",
+      "sha512": "2wmtDnzXROWctOe4xSAMi7qOnnv6IWbxaCyaVbmEqztGL2Uv3QJMPWJ9fzR7SNl9DQgzl4R0KdlrBWP03vmGrA==",
       "type": "package",
+      "path": "system.linq.queryable/4.0.1",
       "files": [
-        "System.Linq.Queryable.4.0.1.nupkg.sha512",
-        "System.Linq.Queryable.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/monoandroid10/_._",
@@ -18120,15 +19205,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.linq.queryable.4.0.1.nupkg.sha512",
+        "system.linq.queryable.nuspec"
       ]
     },
     "System.Net.Http/4.1.0": {
-      "sha512": "ULq9g3SOPVuupt+Y3U+A37coXzdNisB1neFCSKzBwo182u0RDddKJF8I5+HfyXqK6OhJPgeoAwWXrbiUXuRDsg==",
+      "sha512": "r6HKFGym4sxMlvyrq43Rd65lOEA26bmZQO6OHmzeO+P3hv75pOmpX10+P7U/EW5YeNoC4lceamDBzzykF2brQw==",
       "type": "package",
+      "path": "system.net.http/4.1.0",
       "files": [
-        "System.Net.Http.4.1.0.nupkg.sha512",
-        "System.Net.Http.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/Xamarinmac20/_._",
@@ -18199,15 +19285,16 @@
         "runtimes/unix/lib/netstandard1.6/System.Net.Http.dll",
         "runtimes/win/lib/net46/System.Net.Http.dll",
         "runtimes/win/lib/netcore50/System.Net.Http.dll",
-        "runtimes/win/lib/netstandard1.3/System.Net.Http.dll"
+        "runtimes/win/lib/netstandard1.3/System.Net.Http.dll",
+        "system.net.http.4.1.0.nupkg.sha512",
+        "system.net.http.nuspec"
       ]
     },
     "System.Net.Http.Rtc/4.0.1": {
       "sha512": "o2AlTAvlZOc0dRUpmr379G57VUjSQ+JO7X2vIduaV+zReroM7WVwvtg6q1tGBrT4aVFvqWPDavWuBgSMTwugyw==",
       "type": "package",
+      "path": "system.net.http.rtc/4.0.1",
       "files": [
-        "System.Net.Http.Rtc.4.0.1.nupkg.sha512",
-        "System.Net.Http.Rtc.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/win8/_._",
@@ -18234,15 +19321,16 @@
         "ref/netstandard1.1/zh-hans/System.Net.Http.Rtc.xml",
         "ref/netstandard1.1/zh-hant/System.Net.Http.Rtc.xml",
         "ref/win8/_._",
-        "runtimes/win/lib/netcore50/System.Net.Http.Rtc.dll"
+        "runtimes/win/lib/netcore50/System.Net.Http.Rtc.dll",
+        "system.net.http.rtc.4.0.1.nupkg.sha512",
+        "system.net.http.rtc.nuspec"
       ]
     },
     "System.Net.NameResolution/4.0.0": {
-      "sha512": "JdqRdM1Qym3YehqdKIi5LHrpypP4JMfxKQSNCJ2z4WawkG0il+N3XfNeJOxll2XrTnG7WgYYPoeiu/KOwg0DQw==",
+      "sha512": "f5/wbjRx6UPZY4f9WZMIXG0a8iXELbZqbAHp5Xon30t42zEVOvKT1SaqBLt34kKABX7glXEYbttG4+QxIUGuYA==",
       "type": "package",
+      "path": "system.net.nameresolution/4.0.0",
       "files": [
-        "System.Net.NameResolution.4.0.0.nupkg.sha512",
-        "System.Net.NameResolution.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18273,15 +19361,16 @@
         "runtimes/unix/lib/netstandard1.3/System.Net.NameResolution.dll",
         "runtimes/win/lib/net46/System.Net.NameResolution.dll",
         "runtimes/win/lib/netcore50/System.Net.NameResolution.dll",
-        "runtimes/win/lib/netstandard1.3/System.Net.NameResolution.dll"
+        "runtimes/win/lib/netstandard1.3/System.Net.NameResolution.dll",
+        "system.net.nameresolution.4.0.0.nupkg.sha512",
+        "system.net.nameresolution.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.1.0": {
       "sha512": "Q0rfeiW6QsiZuicGjrFA7cRr2+kXex0JIljTTxzI09GIftB8k+aNL31VsQD1sI2g31cw7UGDTgozA/FgeNSzsQ==",
       "type": "package",
+      "path": "system.net.networkinformation/4.1.0",
       "files": [
-        "System.Net.NetworkInformation.4.1.0.nupkg.sha512",
-        "System.Net.NetworkInformation.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18345,15 +19434,16 @@
         "runtimes/osx/lib/netstandard1.3/System.Net.NetworkInformation.dll",
         "runtimes/win/lib/net46/System.Net.NetworkInformation.dll",
         "runtimes/win/lib/netcore50/System.Net.NetworkInformation.dll",
-        "runtimes/win/lib/netstandard1.3/System.Net.NetworkInformation.dll"
+        "runtimes/win/lib/netstandard1.3/System.Net.NetworkInformation.dll",
+        "system.net.networkinformation.4.1.0.nupkg.sha512",
+        "system.net.networkinformation.nuspec"
       ]
     },
     "System.Net.Primitives/4.0.11": {
-      "sha512": "hVvfl4405DRjA2408luZekbPhplJK03j2Y2lSfMlny7GHXlkByw1iLnc9mgKW0GdQn73vvMcWrWewAhylXA4Nw==",
+      "sha512": "9unCVk/z33bFKm0wT6jege7ALVWlJm1SJM5zJ5wA+pi2u5kM/MfosP/tjg8eXk97LYhng8/szT+iQSdTUBVkgw==",
       "type": "package",
+      "path": "system.net.primitives/4.0.11",
       "files": [
-        "System.Net.Primitives.4.0.11.nupkg.sha512",
-        "System.Net.Primitives.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18421,15 +19511,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.net.primitives.4.0.11.nupkg.sha512",
+        "system.net.primitives.nuspec"
       ]
     },
     "System.Net.Requests/4.0.11": {
-      "sha512": "vxGt7C0cZixN+VqoSW4Yakc1Y9WknmxauDqzxgpw/FnBdz4kQNN51l4wxdXX5VY1xjqy//+G+4CvJWp1+f+y6Q==",
+      "sha512": "x5J6yF5B+LxhbLLbumf9BjFMsO52tgbU1VQlIOpGpqjOlqwKLauITQKcne5DmAUcLDXG5yhHKlfXedjLlQwqLQ==",
       "type": "package",
+      "path": "system.net.requests/4.0.11",
       "files": [
-        "System.Net.Requests.4.0.11.nupkg.sha512",
-        "System.Net.Requests.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18501,15 +19592,16 @@
         "ref/xamarinwatchos10/_._",
         "runtimes/unix/lib/netstandard1.3/System.Net.Requests.dll",
         "runtimes/win/lib/net46/_._",
-        "runtimes/win/lib/netstandard1.3/System.Net.Requests.dll"
+        "runtimes/win/lib/netstandard1.3/System.Net.Requests.dll",
+        "system.net.requests.4.0.11.nupkg.sha512",
+        "system.net.requests.nuspec"
       ]
     },
     "System.Net.Sockets/4.1.0": {
-      "sha512": "xAz0N3dAV/aR/9g8r0Y5oEqU1JRsz29F5EGb/WVHmX3jVSLqi2/92M5hTad2aNWovruXrJpJtgZ9fccPMG9uSw==",
+      "sha512": "3CGzOZC5DmE6LAzo+o/roObhUzy6TMvqiuhdqUbxAZjcE1jZQqksGcbhOr/RARVTVxTByA1b0qkvNHpdnFe+4Q==",
       "type": "package",
+      "path": "system.net.sockets/4.1.0",
       "files": [
-        "System.Net.Sockets.4.1.0.nupkg.sha512",
-        "System.Net.Sockets.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18536,15 +19628,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.net.sockets.4.1.0.nupkg.sha512",
+        "system.net.sockets.nuspec"
       ]
     },
     "System.Net.WebHeaderCollection/4.0.1": {
-      "sha512": "XX2TIAN+wBSAIV51BU2FvvXMdstUa8b0FBSZmDWjZdwUMmggQSifpTOZ5fNH20z9ZCg2fkV1L5SsZnpO2RQDRQ==",
+      "sha512": "xv6d96i6/6dnr/8NyIl+TIetqYEk2U8cQXHptG1Z4K81g8zDb2PMu8W4/DWhaN1xlN9G+FOpea1EopWfjo+91g==",
       "type": "package",
+      "path": "system.net.webheadercollection/4.0.1",
       "files": [
-        "System.Net.WebHeaderCollection.4.0.1.nupkg.sha512",
-        "System.Net.WebHeaderCollection.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18572,15 +19665,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.net.webheadercollection.4.0.1.nupkg.sha512",
+        "system.net.webheadercollection.nuspec"
       ]
     },
     "System.Net.WebSockets/4.0.0": {
-      "sha512": "2KJo8hir6Edi9jnMDAMhiJoI691xRBmKcbNpwjrvpIMOCTYOtBpSsSEGBxBDV7PKbasJNaFp1+PZz1D7xS41Hg==",
+      "sha512": "lpRCrCZaJvftIxhqxzltI9VoIXLZ0cxfjA3X1pQ7Ny4EM/bEMfgRMp3/rdRmTixiqy/obh13UqIXisk3mJVHoA==",
       "type": "package",
+      "path": "system.net.websockets/4.0.0",
       "files": [
-        "System.Net.WebSockets.4.0.0.nupkg.sha512",
-        "System.Net.WebSockets.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18608,15 +19702,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.net.websockets.4.0.0.nupkg.sha512",
+        "system.net.websockets.nuspec"
       ]
     },
     "System.Net.WebSockets.Client/4.0.0": {
       "sha512": "GY5h9cn0ZVsG4ORQqMytTldrqxet2RC2CSEsgWGf4XNW5jhL5SxzcUZph03xbZsgn7K3qMr+Rq+gkbJNI+FEXg==",
       "type": "package",
+      "path": "system.net.websockets.client/4.0.0",
       "files": [
-        "System.Net.WebSockets.Client.4.0.0.nupkg.sha512",
-        "System.Net.WebSockets.Client.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18647,15 +19742,16 @@
         "runtimes/unix/lib/netstandard1.3/System.Net.WebSockets.Client.dll",
         "runtimes/win/lib/net46/System.Net.WebSockets.Client.dll",
         "runtimes/win/lib/netcore50/System.Net.WebSockets.Client.dll",
-        "runtimes/win/lib/netstandard1.3/System.Net.WebSockets.Client.dll"
+        "runtimes/win/lib/netstandard1.3/System.Net.WebSockets.Client.dll",
+        "system.net.websockets.client.4.0.0.nupkg.sha512",
+        "system.net.websockets.client.nuspec"
       ]
     },
     "System.Numerics.Vectors/4.1.1": {
-      "sha512": "Ex1NSKycC2wi5XBMWUGWPc3lumh6OQWFFmmpZFZz0oLht5lQ+wWPHVZumOrMJuckfUiVMd4p67BrkBos8lcF+Q==",
+      "sha512": "aCiybWLZM4LYp31N5CaiyxGzhqeNIaOiCxsDjc4BsP59+JzQWPVOjW/8OfABazv2DEn10PvnaoMFPWCfopTThw==",
       "type": "package",
+      "path": "system.numerics.vectors/4.1.1",
       "files": [
-        "System.Numerics.Vectors.4.1.1.nupkg.sha512",
-        "System.Numerics.Vectors.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18679,26 +19775,28 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.numerics.vectors.4.1.1.nupkg.sha512",
+        "system.numerics.vectors.nuspec"
       ]
     },
     "System.Numerics.Vectors.WindowsRuntime/4.0.1": {
       "sha512": "T4RJY6Z+0AuynCnMy8VMyP1g2mrB/OGubx5Og6d8ve6LkVLPrpiGtV5iMJeBv7lTDF1zhviILg+LecgKBjkWag==",
       "type": "package",
+      "path": "system.numerics.vectors.windowsruntime/4.0.1",
       "files": [
-        "System.Numerics.Vectors.WindowsRuntime.4.0.1.nupkg.sha512",
-        "System.Numerics.Vectors.WindowsRuntime.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
-        "lib/uap10.0/System.Numerics.Vectors.WindowsRuntime.dll"
+        "lib/uap10.0/System.Numerics.Vectors.WindowsRuntime.dll",
+        "system.numerics.vectors.windowsruntime.4.0.1.nupkg.sha512",
+        "system.numerics.vectors.windowsruntime.nuspec"
       ]
     },
     "System.ObjectModel/4.0.12": {
-      "sha512": "tAgJM1xt3ytyMoW4qn4wIqgJYm7L7TShRZG4+Q4Qsi2PCcj96pXN7nRywS9KkB3p/xDUjc2HSwP9SROyPYDYKQ==",
+      "sha512": "MdscHV3dta+dh0k+gEyuRsu3McNuiRGzQqy+rKZ2FJFDwn5Jv1LSm0FKYuX0F2+g8JvaaSKZlcvhpSc5kLL+LA==",
       "type": "package",
+      "path": "system.objectmodel/4.0.12",
       "files": [
-        "System.ObjectModel.4.0.12.nupkg.sha512",
-        "System.ObjectModel.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18757,53 +19855,57 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.objectmodel.4.0.12.nupkg.sha512",
+        "system.objectmodel.nuspec"
       ]
     },
     "System.Private.DataContractSerialization/4.1.1": {
       "sha512": "lcqFBUaCZxPiUkA4dlSOoPZGtZsAuuElH2XHgLwGLxd7ZozWetV5yiz0qGAV2AUYOqw97MtZBjbLMN16Xz4vXA==",
       "type": "package",
+      "path": "system.private.datacontractserialization/4.1.1",
       "files": [
-        "System.Private.DataContractSerialization.4.1.1.nupkg.sha512",
-        "System.Private.DataContractSerialization.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/netstandard1.3/System.Private.DataContractSerialization.dll",
         "ref/netstandard/_._",
-        "runtimes/aot/lib/netcore50/System.Private.DataContractSerialization.dll"
+        "runtimes/aot/lib/netcore50/System.Private.DataContractSerialization.dll",
+        "system.private.datacontractserialization.4.1.1.nupkg.sha512",
+        "system.private.datacontractserialization.nuspec"
       ]
     },
     "System.Private.ServiceModel/4.1.0": {
       "sha512": "/QviVqIgta03ms7IDFALHCJOQCANZ1lILobf/OoLzdphHN40M3r6zqso2NsKvvSV7rJus+QLLWS/q33XGIybrQ==",
       "type": "package",
+      "path": "system.private.servicemodel/4.1.0",
       "files": [
-        "System.Private.ServiceModel.4.1.0.nupkg.sha512",
-        "System.Private.ServiceModel.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtimes/unix/lib/netstandard1.3/System.Private.ServiceModel.dll",
         "runtimes/win7/lib/netcore50/System.Private.ServiceModel.dll",
-        "runtimes/win7/lib/netstandard1.3/System.Private.ServiceModel.dll"
+        "runtimes/win7/lib/netstandard1.3/System.Private.ServiceModel.dll",
+        "system.private.servicemodel.4.1.0.nupkg.sha512",
+        "system.private.servicemodel.nuspec"
       ]
     },
     "System.Private.Uri/4.0.1": {
       "sha512": "OltceAn9yyNf9LZIqvf80DhdRH55iVu1fxowdR79018w1CWIRNojUZBStsiRHvADeKI5pXcM9EftOFikBQh5AA==",
       "type": "package",
+      "path": "system.private.uri/4.0.1",
       "files": [
-        "System.Private.Uri.4.0.1.nupkg.sha512",
-        "System.Private.Uri.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
-        "ref/netstandard/_._"
+        "ref/netstandard/_._",
+        "system.private.uri.4.0.1.nupkg.sha512",
+        "system.private.uri.nuspec"
       ]
     },
     "System.Reflection/4.1.0": {
-      "sha512": "JCKANJ0TI7kzoQzuwB/OoJANy1Lg338B6+JVacPl4TpUwi3cReg3nMLplMq2uqYfHFQpKIlHAUVAJlImZz/4ng==",
+      "sha512": "0RqyxkqB2RnuwHcaRiJBt8KLkrvuv8tUA1to49bLlro1uPTmxP/twVTNMLUmiQaZ8rXG94QyNwvfgddsUrvW8w==",
       "type": "package",
+      "path": "system.reflection/4.1.0",
       "files": [
-        "System.Reflection.4.1.0.nupkg.sha512",
-        "System.Reflection.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18873,15 +19975,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.reflection.4.1.0.nupkg.sha512",
+        "system.reflection.nuspec"
       ]
     },
     "System.Reflection.Context/4.0.1": {
       "sha512": "nU4qA/juVb7OCAqLdWAnxeyTjs5tbwQmtF6ep1gTVSa79aGF1J5orD88WHQmNhgVbgfhSGPnz4+d94o/iBXZ7g==",
       "type": "package",
+      "path": "system.reflection.context/4.0.1",
       "files": [
-        "System.Reflection.Context.4.0.1.nupkg.sha512",
-        "System.Reflection.Context.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/net45/_._",
@@ -18913,15 +20016,16 @@
         "ref/netstandard1.1/zh-hans/System.Reflection.Context.xml",
         "ref/netstandard1.1/zh-hant/System.Reflection.Context.xml",
         "ref/portable-net45+win8/_._",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.reflection.context.4.0.1.nupkg.sha512",
+        "system.reflection.context.nuspec"
       ]
     },
     "System.Reflection.DispatchProxy/4.0.1": {
-      "sha512": "GPPgWoSxQEU3aCKSOvsAc1dhTTi4iq92PUVEVfnGPGwqCf6synaAJGYLKMs5E3CuRfel8ufACWUijXqDpOlGrA==",
+      "sha512": "n4z7Zqjap6duX+2wHm2gzEdzxanK2ArX3YoJ7jJ2Xv+WH2F+unoMyFtFLmWrsddpAX0h4hfKJOcTLmbk1RLivw==",
       "type": "package",
+      "path": "system.reflection.dispatchproxy/4.0.1",
       "files": [
-        "System.Reflection.DispatchProxy.4.0.1.nupkg.sha512",
-        "System.Reflection.DispatchProxy.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18948,15 +20052,16 @@
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
-        "runtimes/aot/lib/netcore50/System.Reflection.DispatchProxy.dll"
+        "runtimes/aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "system.reflection.dispatchproxy.4.0.1.nupkg.sha512",
+        "system.reflection.dispatchproxy.nuspec"
       ]
     },
     "System.Reflection.Emit/4.0.1": {
-      "sha512": "P2wqAj72fFjpP6wb9nSfDqNBMab+2ovzSDzUZK7MVIm54tBJEPr9jWfSjjoTpPwj1LeKcmX3vr0ttyjSSFM47g==",
+      "sha512": "dufoZEQBtyqxEWNBxZ4Mc1K7OiBwUaxkka+6PYWMtNj/S/mgZWA/ZU3p1YmcSJ+uoZ15VZfoMrsJ+9Pp+uY5kQ==",
       "type": "package",
+      "path": "system.reflection.emit/4.0.1",
       "files": [
-        "System.Reflection.Emit.4.0.1.nupkg.sha512",
-        "System.Reflection.Emit.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -18977,15 +20082,16 @@
         "ref/netstandard1.1/ru/System.Reflection.Emit.xml",
         "ref/netstandard1.1/zh-hans/System.Reflection.Emit.xml",
         "ref/netstandard1.1/zh-hant/System.Reflection.Emit.xml",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.reflection.emit.4.0.1.nupkg.sha512",
+        "system.reflection.emit.nuspec"
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.1": {
-      "sha512": "Ov6dU8Bu15Bc7zuqttgHF12J5lwSWyTf1S+FJouUXVMSqImLZzYaQ+vRr1rQ0OZ0HqsrwWl4dsKHELckQkVpgA==",
+      "sha512": "xPPXdWfnVI39/Wv6h2NW8KQYMo4NUcQfpu7FEh9U+zpNaLd3+E5XumfE1OYwmqmbvNVdWOwsGUZFBn4g7tOrAQ==",
       "type": "package",
+      "path": "system.reflection.emit.ilgeneration/4.0.1",
       "files": [
-        "System.Reflection.Emit.ILGeneration.4.0.1.nupkg.sha512",
-        "System.Reflection.Emit.ILGeneration.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/net45/_._",
@@ -19007,15 +20113,16 @@
         "ref/netstandard1.0/zh-hant/System.Reflection.Emit.ILGeneration.xml",
         "ref/portable-net45+wp8/_._",
         "ref/wp80/_._",
-        "runtimes/aot/lib/netcore50/_._"
+        "runtimes/aot/lib/netcore50/_._",
+        "system.reflection.emit.ilgeneration.4.0.1.nupkg.sha512",
+        "system.reflection.emit.ilgeneration.nuspec"
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.1": {
-      "sha512": "sSzHHXueZ5Uh0OLpUQprhr+ZYJrLPA2Cmr4gn0wj9+FftNKXx8RIMKvO9qnjk2ebPYUjZ+F2ulGdPOsvj+MEjA==",
+      "sha512": "XJGLOMeyZpdWllV9ORBXPV1LvzMt+RYCJ0aZirlwcappLSwp5B9u85lgi0ySIH+WO4M7AohgL8iYBUMVlrrKWw==",
       "type": "package",
+      "path": "system.reflection.emit.lightweight/4.0.1",
       "files": [
-        "System.Reflection.Emit.Lightweight.4.0.1.nupkg.sha512",
-        "System.Reflection.Emit.Lightweight.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/net45/_._",
@@ -19037,15 +20144,16 @@
         "ref/netstandard1.0/zh-hant/System.Reflection.Emit.Lightweight.xml",
         "ref/portable-net45+wp8/_._",
         "ref/wp80/_._",
-        "runtimes/aot/lib/netcore50/_._"
+        "runtimes/aot/lib/netcore50/_._",
+        "system.reflection.emit.lightweight.4.0.1.nupkg.sha512",
+        "system.reflection.emit.lightweight.nuspec"
       ]
     },
     "System.Reflection.Extensions/4.0.1": {
-      "sha512": "GYrtRsZcMuHF3sbmRHfMYpvxZoIN2bQGrYGerUiWLEkqdEUQZhH3TRSaC/oI4wO0II1RKBPlpIa1TOMxIcOOzQ==",
+      "sha512": "e7uxrXgtHPgaDUc6Fpc8qpnbuQ5FFarPQPp6Aom2ETeXzkqGJRGt20SyRgAhXoWX1TcfMyDzjQpCStslKYK1Rg==",
       "type": "package",
+      "path": "system.reflection.extensions/4.0.1",
       "files": [
-        "System.Reflection.Extensions.4.0.1.nupkg.sha512",
-        "System.Reflection.Extensions.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19091,29 +20199,31 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.reflection.extensions.4.0.1.nupkg.sha512",
+        "system.reflection.extensions.nuspec"
       ]
     },
     "System.Reflection.Metadata/1.3.0": {
-      "sha512": "jMSCxA4LSyKBGRDm/WtfkO03FkcgRzHxwvQRib1bm2GZ8ifKM1MX1al6breGCEQK280mdl9uQS7JNPXRYk90jw==",
+      "sha512": "1CK+3SBFcxX7UfSkEhyCWQ0c3CwNe5ll0VeO4GkHiAFgzLecTsv9S64+q1fPvAbK2kadb8Gg0qaD0NLRpOBczg==",
       "type": "package",
+      "path": "system.reflection.metadata/1.3.0",
       "files": [
-        "System.Reflection.Metadata.1.3.0.nupkg.sha512",
-        "System.Reflection.Metadata.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/netstandard1.1/System.Reflection.Metadata.dll",
         "lib/netstandard1.1/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
-        "lib/portable-net45+win8/System.Reflection.Metadata.xml"
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "system.reflection.metadata.1.3.0.nupkg.sha512",
+        "system.reflection.metadata.nuspec"
       ]
     },
     "System.Reflection.Primitives/4.0.1": {
-      "sha512": "4inTox4wTBaDhB7V3mPvp9XlCbeGYWVEM9/fXALd52vNEAVisc1BoVWQPuUuD0Ga//dNbA/WeMy9u9mzLxGTHQ==",
+      "sha512": "BegoP1A6WYXbohbIWFaLKTfLiRYf61PVuyC5I/ZEdh9mekdKpznt1/wqAUEOWzMJiBTJphKVDOBvuXk6cM7j4g==",
       "type": "package",
+      "path": "system.reflection.primitives/4.0.1",
       "files": [
-        "System.Reflection.Primitives.4.0.1.nupkg.sha512",
-        "System.Reflection.Primitives.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19159,15 +20269,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.reflection.primitives.4.0.1.nupkg.sha512",
+        "system.reflection.primitives.nuspec"
       ]
     },
     "System.Reflection.TypeExtensions/4.1.0": {
-      "sha512": "tsQ/ptQ3H5FYfON8lL4MxRk/8kFyE0A+tGPXmVP967cT/gzLHYxIejIYSxp4JmIeFHVP78g/F2FE1mUUTbDtrg==",
+      "sha512": "Iz7JobYNMCI2hHTWixbfIqejLYM3OAI1SwdsP0qWsKH029pSkXjHQ3g9uwceqvLapipmcyThaOzg2h7f128MTw==",
       "type": "package",
+      "path": "system.reflection.typeextensions/4.1.0",
       "files": [
-        "System.Reflection.TypeExtensions.4.1.0.nupkg.sha512",
-        "System.Reflection.TypeExtensions.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19210,15 +20321,16 @@
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
-        "runtimes/aot/lib/netcore50/System.Reflection.TypeExtensions.dll"
+        "runtimes/aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "system.reflection.typeextensions.4.1.0.nupkg.sha512",
+        "system.reflection.typeextensions.nuspec"
       ]
     },
     "System.Resources.ResourceManager/4.0.1": {
-      "sha512": "TxwVeUNoTgUOdQ09gfTjvW411MF+w9MBYL7AtNVc+HtBCFlutPLhUCdZjNkjbhj3bNQWMdHboF0KIWEOjJssbA==",
+      "sha512": "PLR16XFdiXXqleIR3PVvrICMSfasiKgizAZELwEs5Hs6NMHx35xZp2APb5F6Ek3FskuXbLDlcGPWGu0K7rX2zw==",
       "type": "package",
+      "path": "system.resources.resourcemanager/4.0.1",
       "files": [
-        "System.Resources.ResourceManager.4.0.1.nupkg.sha512",
-        "System.Resources.ResourceManager.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19264,15 +20376,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.resources.resourcemanager.4.0.1.nupkg.sha512",
+        "system.resources.resourcemanager.nuspec"
       ]
     },
     "System.Runtime/4.1.0": {
-      "sha512": "v6c/4Yaa9uWsq+JMhnOFewrYkgdNHNG2eMKuNqRn8P733rNXeRCGvV5FkkjBXn2dbVkPXOsO0xjsEeM1q2zC0g==",
+      "sha512": "YPBYyY6aodk+FrtzgtVKP0LJBmzjmfMEr2dfRA3dl6sRR1TdGhvLTQO0CV/fC6swiA1QdVr/acxc0/gn17xiKw==",
       "type": "package",
+      "path": "system.runtime/4.1.0",
       "files": [
-        "System.Runtime.4.1.0.nupkg.sha512",
-        "System.Runtime.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19353,15 +20466,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.runtime.4.1.0.nupkg.sha512",
+        "system.runtime.nuspec"
       ]
     },
     "System.Runtime.Extensions/4.1.0": {
-      "sha512": "CUOHjTT/vgP0qGW22U4/hDlOqXmcPq5YicBaXdUR2UiUoLwBT+olO6we4DVbq57jeX5uXH2uerVZhf0qGj+sVQ==",
+      "sha512": "5uKsTXpZskuT+VScr3Mngx96B+QSvGdXokHyect0jXB8c92b8Shygt8Q/ApcWivuqTMKw8aYlFT4k+4jLuBXLQ==",
       "type": "package",
+      "path": "system.runtime.extensions/4.1.0",
       "files": [
-        "System.Runtime.Extensions.4.1.0.nupkg.sha512",
-        "System.Runtime.Extensions.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19431,15 +20545,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.runtime.extensions.4.1.0.nupkg.sha512",
+        "system.runtime.extensions.nuspec"
       ]
     },
     "System.Runtime.Handles/4.0.1": {
-      "sha512": "nCJvEKguXEvk2ymk1gqj625vVnlK3/xdGzx0vOKicQkoquaTBJTP13AIYkocSUwHCLNBwUbXTqTWGDxBTWpt7g==",
+      "sha512": "2/PGbaPcaI29B4bSmYR1+Tuztj922JBoE3QAnZ8pygj+nRILLRaOwf2U09b/nWvbxBaDrU3krsMRuphHq/tTRw==",
       "type": "package",
+      "path": "system.runtime.handles/4.0.1",
       "files": [
-        "System.Runtime.Handles.4.0.1.nupkg.sha512",
-        "System.Runtime.Handles.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19466,15 +20581,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.runtime.handles.4.0.1.nupkg.sha512",
+        "system.runtime.handles.nuspec"
       ]
     },
     "System.Runtime.InteropServices/4.1.0": {
-      "sha512": "16eu3kjHS633yYdkjwShDHZLRNMKVi/s0bY8ODiqJ2RfMhDMAwxZaUaWVnZ2P71kr/or+X9o/xFWtNqz8ivieQ==",
+      "sha512": "sLaNGQNGzDZSq2wMvQNjQXT3hNKQ0s2KXVij0eGcjmYgLeC0r9LSy116XLMjbQwwDzZkR+UnrZTvwFVMIQkaDw==",
       "type": "package",
+      "path": "system.runtime.interopservices/4.1.0",
       "files": [
-        "System.Runtime.InteropServices.4.1.0.nupkg.sha512",
-        "System.Runtime.InteropServices.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19553,15 +20669,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.runtime.interopservices.4.1.0.nupkg.sha512",
+        "system.runtime.interopservices.nuspec"
       ]
     },
     "System.Runtime.InteropServices.WindowsRuntime/4.0.1": {
       "sha512": "oIIXM4w2y3MiEZEXA+RTtfPV+SZ1ymbFdWppHlUciNdNIL0/Uo3HW9q9iN2O7T7KUmRdvjA7C2Gv4exAyW4zEQ==",
       "type": "package",
+      "path": "system.runtime.interopservices.windowsruntime/4.0.1",
       "files": [
-        "System.Runtime.InteropServices.WindowsRuntime.4.0.1.nupkg.sha512",
-        "System.Runtime.InteropServices.WindowsRuntime.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/net45/_._",
@@ -19599,15 +20716,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll"
+        "runtimes/aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "system.runtime.interopservices.windowsruntime.4.0.1.nupkg.sha512",
+        "system.runtime.interopservices.windowsruntime.nuspec"
       ]
     },
     "System.Runtime.Numerics/4.0.1": {
-      "sha512": "+XbKFuzdmLP3d1o9pdHu2nxjNr2OEPqGzKeegPLCUMM71a0t50A/rOcIRmGs9wR7a8KuHX6hYs/7/TymIGLNqg==",
+      "sha512": "bMSI3i/Xetg0GOFzE0HBCYkZqkyuLhj6D7kayTZ7/jp8lbSyZRmc8ZEJkUTxtUcq1RWifKfKVCJyOK8OhXDH7g==",
       "type": "package",
+      "path": "system.runtime.numerics/4.0.1",
       "files": [
-        "System.Runtime.Numerics.4.0.1.nupkg.sha512",
-        "System.Runtime.Numerics.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19653,15 +20771,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.runtime.numerics.4.0.1.nupkg.sha512",
+        "system.runtime.numerics.nuspec"
       ]
     },
     "System.Runtime.Serialization.Json/4.0.2": {
       "sha512": "+7DIJhnKYgCzUgcLbVTtRQb2l1M0FP549XFlFkQM5lmNiUBl44AfNbx4bz61xA8PzLtlYwfmif4JJJW7MPPnjg==",
       "type": "package",
+      "path": "system.runtime.serialization.json/4.0.2",
       "files": [
-        "System.Runtime.Serialization.Json.4.0.2.nupkg.sha512",
-        "System.Runtime.Serialization.Json.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19709,15 +20828,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.runtime.serialization.json.4.0.2.nupkg.sha512",
+        "system.runtime.serialization.json.nuspec"
       ]
     },
     "System.Runtime.Serialization.Primitives/4.1.1": {
-      "sha512": "HZ6Du5QrTG8MNJbf4e4qMO3JRAkIboGT5Fk804uZtg3Gq516S7hAqTm2UZKUHa7/6HUGdVy3AqMQKbns06G/cg==",
+      "sha512": "FVuzgoT1CzZWG6ilPNM5/DkVRqS1sE/8UyvU3JLIqc2QzSx3QNYBX3019Xs9G9HEtGWHF3FMT0nmxMG/+Sh2Nw==",
       "type": "package",
+      "path": "system.runtime.serialization.primitives/4.1.1",
       "files": [
-        "System.Runtime.Serialization.Primitives.4.1.1.nupkg.sha512",
-        "System.Runtime.Serialization.Primitives.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19779,15 +20899,16 @@
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
-        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.Primitives.dll"
+        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.Primitives.dll",
+        "system.runtime.serialization.primitives.4.1.1.nupkg.sha512",
+        "system.runtime.serialization.primitives.nuspec"
       ]
     },
     "System.Runtime.Serialization.Xml/4.1.1": {
       "sha512": "yqfKHkWUAdI0hdDIdD9KDzluKtZ8IIqLF3O7xIZlt6UTs1bOvFRpCvRTvGQva3Ak/ZM9/nq9IHBJ1tC4Ybcrjg==",
       "type": "package",
+      "path": "system.runtime.serialization.xml/4.1.1",
       "files": [
-        "System.Runtime.Serialization.Xml.4.1.1.nupkg.sha512",
-        "System.Runtime.Serialization.Xml.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19848,15 +20969,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.runtime.serialization.xml.4.1.1.nupkg.sha512",
+        "system.runtime.serialization.xml.nuspec"
       ]
     },
     "System.Runtime.WindowsRuntime/4.0.11": {
       "sha512": "C7rjmukRI0zE1Upl9hhmO4ZxasFYUTadXtgikLTgWwmIwa1jAD7yhOHKX3odajlRnSt34Ih+5VZliaqfFvQOcg==",
       "type": "package",
+      "path": "system.runtime.windowsruntime/4.0.11",
       "files": [
-        "System.Runtime.WindowsRuntime.4.0.11.nupkg.sha512",
-        "System.Runtime.WindowsRuntime.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/portable-win8+wp8+wpa81/_._",
@@ -19901,15 +21023,16 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll",
-        "runtimes/win8/lib/netstandard1.3/System.Runtime.WindowsRuntime.dll"
+        "runtimes/win8/lib/netstandard1.3/System.Runtime.WindowsRuntime.dll",
+        "system.runtime.windowsruntime.4.0.11.nupkg.sha512",
+        "system.runtime.windowsruntime.nuspec"
       ]
     },
     "System.Runtime.WindowsRuntime.UI.Xaml/4.0.1": {
       "sha512": "ZG2uW8JYmFs1sGlhhAoW/F5WmZotkeSxzMils72qGEsJI6+JcQUa6oleSujULC4nk13F5Us9zvlvD2WfB+9Thw==",
       "type": "package",
+      "path": "system.runtime.windowsruntime.ui.xaml/4.0.1",
       "files": [
-        "System.Runtime.WindowsRuntime.UI.Xaml.4.0.1.nupkg.sha512",
-        "System.Runtime.WindowsRuntime.UI.Xaml.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/portable-win8+wpa81/_._",
@@ -19940,15 +21063,16 @@
         "ref/portable-win8+wpa81/_._",
         "ref/win8/_._",
         "ref/wpa81/_._",
-        "runtimes/win8/lib/netstandard1.3/System.Runtime.WindowsRuntime.UI.Xaml.dll"
+        "runtimes/win8/lib/netstandard1.3/System.Runtime.WindowsRuntime.UI.Xaml.dll",
+        "system.runtime.windowsruntime.ui.xaml.4.0.1.nupkg.sha512",
+        "system.runtime.windowsruntime.ui.xaml.nuspec"
       ]
     },
     "System.Security.Claims/4.0.1": {
-      "sha512": "4Jlp0OgJLS/Voj1kyFP6MJlIYp3crgfH8kNQk2p7+4JYfc1aAmh9PZyAMMbDhuoolGNtux9HqSOazsioRiDvCw==",
+      "sha512": "LmeIy7XD5FpzkVg4vu6szT5shrv+fUFk9HrQ54w76uzAxZ8SlZRsM47YApxrYNDWCez2nqq4LlqDs/QaEuJkjA==",
       "type": "package",
+      "path": "system.security.claims/4.0.1",
       "files": [
-        "System.Security.Claims.4.0.1.nupkg.sha512",
-        "System.Security.Claims.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -19976,15 +21100,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.security.claims.4.0.1.nupkg.sha512",
+        "system.security.claims.nuspec"
       ]
     },
     "System.Security.Cryptography.Algorithms/4.2.0": {
-      "sha512": "8JQFxbLVdrtIOKMDN38Fn0GWnqYZw/oMlwOUG/qz1jqChvyZlnUmu+0s7wLx7JYua/nAXoESpHA3iw11QFWhXg==",
+      "sha512": "T3wSKOnbb3txi5gSWsBdKf6tjuOcqIs/C4rQpaJQDB2UCCY8mAwMry5RQB9Dpv+0sf9dPC+KhgsT35sif6yO+Q==",
       "type": "package",
+      "path": "system.security.cryptography.algorithms/4.2.0",
       "files": [
-        "System.Security.Cryptography.Algorithms.4.2.0.nupkg.sha512",
-        "System.Security.Cryptography.Algorithms.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20013,15 +21138,16 @@
         "runtimes/win/lib/net461/System.Security.Cryptography.Algorithms.dll",
         "runtimes/win/lib/net463/System.Security.Cryptography.Algorithms.dll",
         "runtimes/win/lib/netcore50/System.Security.Cryptography.Algorithms.dll",
-        "runtimes/win/lib/netstandard1.6/System.Security.Cryptography.Algorithms.dll"
+        "runtimes/win/lib/netstandard1.6/System.Security.Cryptography.Algorithms.dll",
+        "system.security.cryptography.algorithms.4.2.0.nupkg.sha512",
+        "system.security.cryptography.algorithms.nuspec"
       ]
     },
     "System.Security.Cryptography.Cng/4.2.0": {
-      "sha512": "cUJ2h+ZvONDe28Szw3st5dOHdjndhJzQ2WObDEXAWRPEQBtVItVoxbXM/OEsTthl3cNn2dk2k0I3y45igCQcLw==",
+      "sha512": "6JICrh6Wj2aUSiGWBcvg33vej3lSeGJwP3sedTE2tw/ose1GxDJYbKuWDlwkeMaLQAVLtmakqXCaJgI9bFvjIw==",
       "type": "package",
+      "path": "system.security.cryptography.cng/4.2.0",
       "files": [
-        "System.Security.Cryptography.Cng.4.2.0.nupkg.sha512",
-        "System.Security.Cryptography.Cng.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/net46/System.Security.Cryptography.Cng.dll",
@@ -20038,15 +21164,16 @@
         "runtimes/win/lib/net461/System.Security.Cryptography.Cng.dll",
         "runtimes/win/lib/net463/System.Security.Cryptography.Cng.dll",
         "runtimes/win/lib/netstandard1.4/System.Security.Cryptography.Cng.dll",
-        "runtimes/win/lib/netstandard1.6/System.Security.Cryptography.Cng.dll"
+        "runtimes/win/lib/netstandard1.6/System.Security.Cryptography.Cng.dll",
+        "system.security.cryptography.cng.4.2.0.nupkg.sha512",
+        "system.security.cryptography.cng.nuspec"
       ]
     },
     "System.Security.Cryptography.Encoding/4.0.0": {
-      "sha512": "FbKgE5MbxSQMPcSVRgwM6bXN3GtyAh04NkV8E5zKCBE26X0vYW0UtTa2FIgkH33WVqBVxRgxljlVYumWtU+HcQ==",
+      "sha512": "z7DiBDsHe5WDtYrxP3UuHimpolb1XHT9Q6opTI3iL2GwHZmWumBcOHUZQNcpWL1I+W2UujPL2I13gVy4sQQzhA==",
       "type": "package",
+      "path": "system.security.cryptography.encoding/4.0.0",
       "files": [
-        "System.Security.Cryptography.Encoding.4.0.0.nupkg.sha512",
-        "System.Security.Cryptography.Encoding.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20076,15 +21203,16 @@
         "ref/xamarinwatchos10/_._",
         "runtimes/unix/lib/netstandard1.3/System.Security.Cryptography.Encoding.dll",
         "runtimes/win/lib/net46/System.Security.Cryptography.Encoding.dll",
-        "runtimes/win/lib/netstandard1.3/System.Security.Cryptography.Encoding.dll"
+        "runtimes/win/lib/netstandard1.3/System.Security.Cryptography.Encoding.dll",
+        "system.security.cryptography.encoding.4.0.0.nupkg.sha512",
+        "system.security.cryptography.encoding.nuspec"
       ]
     },
     "System.Security.Cryptography.Primitives/4.0.0": {
-      "sha512": "Wkd7QryWYjkQclX0bngpntW5HSlMzeJU24UaLJQ7YTfI8ydAVAaU2J+HXLLABOVJlKTVvAeL0Aj39VeTe7L+oA==",
+      "sha512": "bicmzFHx9h9OPI5xUQx3VvrjBnZVdzaI7kOhd3hEFNyR4xp2Ro+Ge19zB/snEzb4z79s95+rI63e6+LGLzLJXg==",
       "type": "package",
+      "path": "system.security.cryptography.primitives/4.0.0",
       "files": [
-        "System.Security.Cryptography.Primitives.4.0.0.nupkg.sha512",
-        "System.Security.Cryptography.Primitives.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20102,15 +21230,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.security.cryptography.primitives.4.0.0.nupkg.sha512",
+        "system.security.cryptography.primitives.nuspec"
       ]
     },
     "System.Security.Cryptography.X509Certificates/4.1.0": {
-      "sha512": "4HEfsQIKAhA1+ApNn729Gi09zh+lYWwyIuViihoMDWp1vQnEkL2ct7mAbhBlLYm+x/L4Rr/pyGge1lIY635e0w==",
+      "sha512": "GuGyKDYHwvPfXSh3hyY/01InUjKoMKOV/IE9jLx0NrfE5Q8arbkyxKEQBvtPqF4xSnLW3hdTS17FpqSvx6tAvg==",
       "type": "package",
+      "path": "system.security.cryptography.x509certificates/4.1.0",
       "files": [
-        "System.Security.Cryptography.X509Certificates.4.1.0.nupkg.sha512",
-        "System.Security.Cryptography.X509Certificates.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20155,15 +21284,16 @@
         "runtimes/win/lib/net46/System.Security.Cryptography.X509Certificates.dll",
         "runtimes/win/lib/net461/System.Security.Cryptography.X509Certificates.dll",
         "runtimes/win/lib/netcore50/System.Security.Cryptography.X509Certificates.dll",
-        "runtimes/win/lib/netstandard1.6/System.Security.Cryptography.X509Certificates.dll"
+        "runtimes/win/lib/netstandard1.6/System.Security.Cryptography.X509Certificates.dll",
+        "system.security.cryptography.x509certificates.4.1.0.nupkg.sha512",
+        "system.security.cryptography.x509certificates.nuspec"
       ]
     },
     "System.Security.Principal/4.0.1": {
-      "sha512": "On+SKhXY5rzxh/S8wlH1Rm0ogBlu7zyHNxeNBiXauNrhHRXAe9EuX8Yl5IOzLPGU5Z4kLWHMvORDOCG8iu9hww==",
+      "sha512": "R2DBVi5YuBpx/aOM57eykf6fDL8A691rkht39JYx+gamtx4III+Bi3RiXdXh7JyGW+l0O1WBJZ2STfHOoQLTNg==",
       "type": "package",
+      "path": "system.security.principal/4.0.1",
       "files": [
-        "System.Security.Principal.4.0.1.nupkg.sha512",
-        "System.Security.Principal.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20211,15 +21341,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.security.principal.4.0.1.nupkg.sha512",
+        "system.security.principal.nuspec"
       ]
     },
     "System.ServiceModel.Duplex/4.0.1": {
       "sha512": "4I6WSQP4BiT3yG5NetAyAb626e2HlsgSzkiiqGtf4LxGpO3uFQ4eGSXsgVRnxJoDYcnDCH7q215eH/jZBMmx+w==",
       "type": "package",
+      "path": "system.servicemodel.duplex/4.0.1",
       "files": [
-        "System.ServiceModel.Duplex.4.0.1.nupkg.sha512",
-        "System.ServiceModel.Duplex.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/net45/_._",
@@ -20251,15 +21382,16 @@
         "ref/netstandard1.1/zh-hans/System.ServiceModel.Duplex.xml",
         "ref/netstandard1.1/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/portable-net45+win8/_._",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.servicemodel.duplex.4.0.1.nupkg.sha512",
+        "system.servicemodel.duplex.nuspec"
       ]
     },
     "System.ServiceModel.Http/4.1.0": {
       "sha512": "sCIV+wrA4Antjnk0+fk6rxpzQkd2bReN4UTipGv5iyPNApVv/KtAfeDMg+YIajJ7VkQD60uVBTQmy3LZrRnNOw==",
       "type": "package",
+      "path": "system.servicemodel.http/4.1.0",
       "files": [
-        "System.ServiceModel.Http.4.1.0.nupkg.sha512",
-        "System.ServiceModel.Http.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20329,15 +21461,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.servicemodel.http.4.1.0.nupkg.sha512",
+        "system.servicemodel.http.nuspec"
       ]
     },
     "System.ServiceModel.NetTcp/4.1.0": {
       "sha512": "n+Ir2B9SAd5XwAaXPIpLQsbaDcscSsyJH0ODpm5tpK8xXxmLhiPct5kujzeAiAhB37lVSetrSINdFb1Llg2ngg==",
       "type": "package",
+      "path": "system.servicemodel.nettcp/4.1.0",
       "files": [
-        "System.ServiceModel.NetTcp.4.1.0.nupkg.sha512",
-        "System.ServiceModel.NetTcp.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/net45/_._",
@@ -20382,15 +21515,16 @@
         "ref/netstandard1.3/zh-hans/System.ServiceModel.NetTcp.xml",
         "ref/netstandard1.3/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/portable-net45+win8/_._",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.servicemodel.nettcp.4.1.0.nupkg.sha512",
+        "system.servicemodel.nettcp.nuspec"
       ]
     },
     "System.ServiceModel.Primitives/4.1.0": {
       "sha512": "Kd65HOn/5pL9xtCUkSL8xVqpqBUYy9tsfo0qe/MTTzApY8WQ+6i4I2ts++M+m4vbOanCoEsjjUj26P6C6ilQjQ==",
       "type": "package",
+      "path": "system.servicemodel.primitives/4.1.0",
       "files": [
-        "System.ServiceModel.Primitives.4.1.0.nupkg.sha512",
-        "System.ServiceModel.Primitives.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20460,15 +21594,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.servicemodel.primitives.4.1.0.nupkg.sha512",
+        "system.servicemodel.primitives.nuspec"
       ]
     },
     "System.ServiceModel.Security/4.0.1": {
       "sha512": "82pkDb6LMq/NHi+DVHZ7zKHMMJ7mR6rVl9TpH+p8zJhZrVYJez9vTbdMsxQhbNOngEkJKzZFveNYpaRv/3RMsg==",
       "type": "package",
+      "path": "system.servicemodel.security/4.0.1",
       "files": [
-        "System.ServiceModel.Security.4.0.1.nupkg.sha512",
-        "System.ServiceModel.Security.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/net45/_._",
@@ -20513,15 +21648,16 @@
         "ref/netstandard1.1/zh-hant/System.ServiceModel.Security.xml",
         "ref/portable-net45+win8+wp8/_._",
         "ref/win8/_._",
-        "ref/wp8/_._"
+        "ref/wp8/_._",
+        "system.servicemodel.security.4.0.1.nupkg.sha512",
+        "system.servicemodel.security.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.11": {
-      "sha512": "U3gGeMlDZXxCEiY4DwVLSacg+DFWCvoiX+JThA/rvw37Sqrku7sEFeVBBBMBnfB6FeZHsyDx85HlKL19x0HtZA==",
+      "sha512": "U+pKoxAyfd5qZdWZb8JGZg79mCVfe/m2iRw16D16WUwhR9S8o6iE6lMOrfMJ9lZMT35k63ooztApBaMeuwyg9w==",
       "type": "package",
+      "path": "system.text.encoding/4.0.11",
       "files": [
-        "System.Text.Encoding.4.0.11.nupkg.sha512",
-        "System.Text.Encoding.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20578,15 +21714,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.text.encoding.4.0.11.nupkg.sha512",
+        "system.text.encoding.nuspec"
       ]
     },
     "System.Text.Encoding.CodePages/4.0.1": {
-      "sha512": "h4z6rrA/hxWf4655D18IIZ0eaLRa3tQC/j+e26W+VinIHY0l07iEXaAvO0YSYq3MvCjMYy8Zs5AdC1sxNQOB7Q==",
+      "sha512": "+A+U+YkIdR+mVLWGVWbrP0a9ItsXYPXIVU7n06cHqf2aD4oJaBmCc8o1V5oLF8PO4R9C67nthg/5j/zBVP0BPg==",
       "type": "package",
+      "path": "system.text.encoding.codepages/4.0.1",
       "files": [
-        "System.Text.Encoding.CodePages.4.0.1.nupkg.sha512",
-        "System.Text.Encoding.CodePages.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20614,15 +21751,16 @@
         "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
         "runtimes/unix/lib/netstandard1.3/System.Text.Encoding.CodePages.dll",
-        "runtimes/win/lib/netstandard1.3/System.Text.Encoding.CodePages.dll"
+        "runtimes/win/lib/netstandard1.3/System.Text.Encoding.CodePages.dll",
+        "system.text.encoding.codepages.4.0.1.nupkg.sha512",
+        "system.text.encoding.codepages.nuspec"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.11": {
-      "sha512": "jtbiTDtvfLYgXn8PTfWI+SiBs51rrmO4AAckx4KR6vFK9Wzf6tI8kcRdsYQNwriUeQ1+CtQbM1W4cMbLXnj/OQ==",
+      "sha512": "5TfzdCrl3NAFCMxOgmLu7NNQ71UYCbjhB02xjponJvZubdwnS7WwLPD2fKZQ11RnnqQpLFhLDs259tCfFHGZyA==",
       "type": "package",
+      "path": "system.text.encoding.extensions/4.0.11",
       "files": [
-        "System.Text.Encoding.Extensions.4.0.11.nupkg.sha512",
-        "System.Text.Encoding.Extensions.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20679,15 +21817,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.text.encoding.extensions.4.0.11.nupkg.sha512",
+        "system.text.encoding.extensions.nuspec"
       ]
     },
     "System.Text.RegularExpressions/4.1.0": {
-      "sha512": "i88YCXpRTjCnoSQZtdlHkAOx4KNNik4hMy83n0+Ftlb7jvV6ZiZWMpnEZHhjBp6hQVh8gWd/iKNPzlPF7iyA2g==",
+      "sha512": "G/UljnFsAzhlWpYk8HjqNhLk8688jjIrzRTHaQl40uxbcS/AXZxLgWex86qFoqY4Z0BlKiwbyf+sTMUwou623w==",
       "type": "package",
+      "path": "system.text.regularexpressions/4.1.0",
       "files": [
-        "System.Text.RegularExpressions.4.1.0.nupkg.sha512",
-        "System.Text.RegularExpressions.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20759,15 +21898,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.text.regularexpressions.4.1.0.nupkg.sha512",
+        "system.text.regularexpressions.nuspec"
       ]
     },
     "System.Threading/4.0.11": {
-      "sha512": "N+3xqIcg3VDKyjwwCGaZ9HawG9aC6cSDI+s7ROma310GQo8vilFZa86hqKppwTHleR/G0sfOzhvgnUxWCR/DrQ==",
+      "sha512": "aGdzqI/Atyts5evljY3FdSyBVufAh7tfv9oyzaTvwXbLDhW1ClsF0fXITwOIzcUi1R2RjhO8/7og8uxHXcZwFQ==",
       "type": "package",
+      "path": "system.threading/4.0.11",
       "files": [
-        "System.Threading.4.0.11.nupkg.sha512",
-        "System.Threading.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20827,15 +21967,16 @@
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
-        "runtimes/aot/lib/netcore50/System.Threading.dll"
+        "runtimes/aot/lib/netcore50/System.Threading.dll",
+        "system.threading.4.0.11.nupkg.sha512",
+        "system.threading.nuspec"
       ]
     },
     "System.Threading.Overlapped/4.0.1": {
-      "sha512": "f7aLuLkBoCQM2kng7zqLFBXz9Gk48gDK8lk1ih9rH/1arJJzZK9gJwNvPDhL6Ps/l6rwOr8jw+4FCHL0KKWiEg==",
+      "sha512": "raGHigTlcGwmrNC6Um0TSs9zbOZh6PofpKb6X8JNBzJHBHAvEg/jhnMUmy+LIC0Hy6Hnja1tSOs6enui3GVP3A==",
       "type": "package",
+      "path": "system.threading.overlapped/4.0.1",
       "files": [
-        "System.Threading.Overlapped.4.0.1.nupkg.sha512",
-        "System.Threading.Overlapped.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/net46/System.Threading.Overlapped.dll",
@@ -20854,15 +21995,16 @@
         "runtimes/unix/lib/netstandard1.3/System.Threading.Overlapped.dll",
         "runtimes/win/lib/net46/System.Threading.Overlapped.dll",
         "runtimes/win/lib/netcore50/System.Threading.Overlapped.dll",
-        "runtimes/win/lib/netstandard1.3/System.Threading.Overlapped.dll"
+        "runtimes/win/lib/netstandard1.3/System.Threading.Overlapped.dll",
+        "system.threading.overlapped.4.0.1.nupkg.sha512",
+        "system.threading.overlapped.nuspec"
       ]
     },
     "System.Threading.Tasks/4.0.11": {
-      "sha512": "k1S4Gc6IGwtHGT8188RSeGaX86Qw/wnrgNLshJvsdNUOPP9etMmo8S07c+UlOAx4K/xLuN9ivA1bD0LVurtIxQ==",
+      "sha512": "7ROfZfxW/X70Bc38kzXcrG/+KUxDg5e9alhiV70hP14qM200IevyEG1cd3SdXAn7Jj7zrDu2pMjYntRfeUgCCg==",
       "type": "package",
+      "path": "system.threading.tasks/4.0.11",
       "files": [
-        "System.Threading.Tasks.4.0.11.nupkg.sha512",
-        "System.Threading.Tasks.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -20919,43 +22061,46 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.threading.tasks.4.0.11.nupkg.sha512",
+        "system.threading.tasks.nuspec"
       ]
     },
     "System.Threading.Tasks.Dataflow/4.6.0": {
-      "sha512": "2hRjGu2r2jxRZ55wmcHO/WbdX+YAOz9x6FE8xqkHZgPaoFMKQZRe9dk8xTZIas8fRjxRmzawnTEWIrhlM+Un7w==",
+      "sha512": "SKCi06qF/exeKj8FCEp/VHNmDpez0gEeh2yv/KAI7uJIU4x2AwjW+7FvGFTUx6pCX5+H+mp/uKRwSm9x4n32NA==",
       "type": "package",
+      "path": "system.threading.tasks.dataflow/4.6.0",
       "files": [
-        "System.Threading.Tasks.Dataflow.4.6.0.nupkg.sha512",
-        "System.Threading.Tasks.Dataflow.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/netstandard1.0/System.Threading.Tasks.Dataflow.XML",
         "lib/netstandard1.0/System.Threading.Tasks.Dataflow.dll",
         "lib/netstandard1.1/System.Threading.Tasks.Dataflow.XML",
-        "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll"
+        "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll",
+        "system.threading.tasks.dataflow.4.6.0.nupkg.sha512",
+        "system.threading.tasks.dataflow.nuspec"
       ]
     },
     "System.Threading.Tasks.Extensions/4.0.0": {
-      "sha512": "pH4FZDsZQ/WmgJtN4LWYmRdJAEeVkyriSwrv2Teoe5FOU0Yxlb6II6GL8dBPOfRmutHGATduj3ooMt7dJ2+i+w==",
+      "sha512": "5wehuomVup/TPiUUCgiEPbJaZHqbeOt3oGsaaDzDLKcABAr5TLO9O52TxA0GZL3RZ8SLkwjMhperw7YRd/JYxw==",
       "type": "package",
+      "path": "system.threading.tasks.extensions/4.0.0",
       "files": [
-        "System.Threading.Tasks.Extensions.4.0.0.nupkg.sha512",
-        "System.Threading.Tasks.Extensions.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/netstandard1.0/System.Threading.Tasks.Extensions.dll",
         "lib/netstandard1.0/System.Threading.Tasks.Extensions.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Extensions.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Extensions.xml"
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Extensions.xml",
+        "system.threading.tasks.extensions.4.0.0.nupkg.sha512",
+        "system.threading.tasks.extensions.nuspec"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.1": {
-      "sha512": "7Pc9t25bcynT9FpMvkUw4ZjYwUiGup/5cJFW72/5MgCG+np2cfVUMdh29u8d7onxX7d8PS3J+wL73zQRqkdrSA==",
+      "sha512": "DepY8S+HhKKr134C+NwelujRQ6ZQvYAlN/FrkvpBxyWrZ1kDQVO351JOqyZbPt1GhsZQ8vZTAHJFuFxaXMqcZw==",
       "type": "package",
+      "path": "system.threading.tasks.parallel/4.0.1",
       "files": [
-        "System.Threading.Tasks.Parallel.4.0.1.nupkg.sha512",
-        "System.Threading.Tasks.Parallel.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -21001,15 +22146,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.threading.tasks.parallel.4.0.1.nupkg.sha512",
+        "system.threading.tasks.parallel.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.1": {
-      "sha512": "saGfUV8uqVW6LeURiqxcGhZ24PzuRNaUBtbhVeuUAvky1naH395A/1nY0P2bWvrw/BreRtIB/EzTDkGBpqCwEw==",
+      "sha512": "mhTFt3uOiCeRTGcgwGJtIe7ux5wlh6XPnHf1pNEX1AIjCgYgyLwnl2ETqNcc5caP5zoRaCJ819hX7LtM+vchnw==",
       "type": "package",
+      "path": "system.threading.timer/4.0.1",
       "files": [
-        "System.Threading.Timer.4.0.1.nupkg.sha512",
-        "System.Threading.Timer.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -21053,15 +22199,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.threading.timer.4.0.1.nupkg.sha512",
+        "system.threading.timer.nuspec"
       ]
     },
     "System.Xml.ReaderWriter/4.0.11": {
-      "sha512": "ZIiLPsf67YZ9zgr31vzrFaYQqxRPX9cVHjtPSnmx4eN6lbS/yEyYNr2vs1doGDEscF0tjCZFsk9yUg1sC9e8tg==",
+      "sha512": "b1QxyqzOwxZQUrAus0yoN5LssvNMhAh784zpqG25MdXvSqvoGaMaX3IohVqrhGrZXAIL/W1A9EUT23agoskIYA==",
       "type": "package",
+      "path": "system.xml.readerwriter/4.0.11",
       "files": [
-        "System.Xml.ReaderWriter.4.0.11.nupkg.sha512",
-        "System.Xml.ReaderWriter.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -21120,15 +22267,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.xml.readerwriter.4.0.11.nupkg.sha512",
+        "system.xml.readerwriter.nuspec"
       ]
     },
     "System.Xml.XDocument/4.0.11": {
-      "sha512": "Mk2mKmPi0nWaoiYeotq1dgeNK1fqWh61+EK+w4Wu8SWuTYLzpUnschb59bJtGywaPq7SmTuPf44wrXRwbIrukg==",
+      "sha512": "NdsceMVWEcwwIlaVSmKQzFYNghsNgZXFnTTK5kF4v8daH0QMX8X83mV1IkLqPVnhSH3aerbIhlmL2EhkAj23bg==",
       "type": "package",
+      "path": "system.xml.xdocument/4.0.11",
       "files": [
-        "System.Xml.XDocument.4.0.11.nupkg.sha512",
-        "System.Xml.XDocument.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -21187,15 +22335,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.xml.xdocument.4.0.11.nupkg.sha512",
+        "system.xml.xdocument.nuspec"
       ]
     },
     "System.Xml.XmlDocument/4.0.1": {
-      "sha512": "2eZu6IP+etFVBBFUFzw2w6J21DqIN5eL9Y8r8JfJWUmV28Z5P0SNU01oCisVHQgHsDhHPnmq2s1hJrJCFZWloQ==",
+      "sha512": "NOGep8bEGshCPk0EqAzyfegF0giRFzTlZgj8hMvYyCE6+dAg/cyNvUalkjHBz8ircLoqiYdl2HRWRExEVaReGw==",
       "type": "package",
+      "path": "system.xml.xmldocument/4.0.1",
       "files": [
-        "System.Xml.XmlDocument.4.0.1.nupkg.sha512",
-        "System.Xml.XmlDocument.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -21223,15 +22372,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._"
+        "ref/xamarinwatchos10/_._",
+        "system.xml.xmldocument.4.0.1.nupkg.sha512",
+        "system.xml.xmldocument.nuspec"
       ]
     },
     "System.Xml.XmlSerializer/4.0.11": {
       "sha512": "FrazwwqfIXTfq23mfv4zH+BjqkSFNaNFBtjzu3I9NRmG8EELYyrv/fJnttCIwRMFRR/YKXF1hmsMmMEnl55HGw==",
       "type": "package",
+      "path": "system.xml.xmlserializer/4.0.11",
       "files": [
-        "System.Xml.XmlSerializer.4.0.11.nupkg.sha512",
-        "System.Xml.XmlSerializer.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "lib/MonoAndroid10/_._",
@@ -21291,8 +22441,15 @@
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
-        "runtimes/aot/lib/netcore50/System.Xml.XmlSerializer.dll"
+        "runtimes/aot/lib/netcore50/System.Xml.XmlSerializer.dll",
+        "system.xml.xmlserializer.4.0.11.nupkg.sha512",
+        "system.xml.xmlserializer.nuspec"
       ]
+    },
+    "Metropolis.UI.MVVM.Core/1.0.0": {
+      "type": "project",
+      "path": "../Metropolis.UI.MVVM.Core/Metropolis.UI.MVVM.Core.csproj",
+      "msbuildProject": "../Metropolis.UI.MVVM.Core/Metropolis.UI.MVVM.Core.csproj"
     }
   },
   "projectFileDependencyGroups": {
@@ -21301,5 +22458,53 @@
       "MvvmCross >= 4.3.0"
     ],
     "UAP,Version=v10.0": []
+  },
+  "packageFolders": {
+    "C:\\Users\\gkarwchan\\.nuget\\packages\\": {}
+  },
+  "project": {
+    "restore": {
+      "projectUniqueName": "C:\\code\\shaw\\mymetro\\src\\Metropolis.UI.MVVM.UWP\\Metropolis.UI.MVVM.UWP.csproj",
+      "projectName": "Metropolis.UI.MVVM.UWP",
+      "projectPath": "C:\\code\\shaw\\mymetro\\src\\Metropolis.UI.MVVM.UWP\\Metropolis.UI.MVVM.UWP.csproj",
+      "projectJsonPath": "C:\\code\\shaw\\mymetro\\src\\Metropolis.UI.MVVM.UWP\\project.json",
+      "projectStyle": "ProjectJson",
+      "frameworks": {
+        "uap10.0": {
+          "projectReferences": {
+            "C:\\code\\shaw\\mymetro\\src\\Metropolis.UI.MVVM.Core\\Metropolis.UI.MVVM.Core.csproj": {
+              "projectPath": "C:\\code\\shaw\\mymetro\\src\\Metropolis.UI.MVVM.Core\\Metropolis.UI.MVVM.Core.csproj"
+            }
+          }
+        }
+      }
+    },
+    "dependencies": {
+      "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
+      "MvvmCross": "4.3.0"
+    },
+    "frameworks": {
+      "uap10.0": {}
+    },
+    "runtimes": {
+      "win10-arm": {
+        "#import": []
+      },
+      "win10-arm-aot": {
+        "#import": []
+      },
+      "win10-x64": {
+        "#import": []
+      },
+      "win10-x64-aot": {
+        "#import": []
+      },
+      "win10-x86": {
+        "#import": []
+      },
+      "win10-x86-aot": {
+        "#import": []
+      }
+    }
   }
 }

--- a/test/Metropolis.Test/Api/Collection/Steps/ECMA/EslintCollectionStepTest.cs
+++ b/test/Metropolis.Test/Api/Collection/Steps/ECMA/EslintCollectionStepTest.cs
@@ -28,9 +28,9 @@ namespace Metropolis.Test.Api.Collection.Steps.ECMA
         [Test]
         public void CanParseCommand_WithIgnoreFile()
         {
-            var expected = $"{NodeModulesPath}eslint -c '{BaseCollectionStep.LocateSettings("default.eslintrc.json")}' '{Args.SourceDirectory}\\**' "+
-                           $"-o '{Result.MetricsFile}' -f checkstyle" +
-                           $" --ignore-path '{Args.IgnoreFile}'";
+            var expected = $"{NodeModulesPath}eslint -c '{BaseCollectionStep.LocateSettings("default.eslintrc.json")}' '{Args.SourceDirectory}'"+
+                           $" --no-eslintrc -o '{Result.MetricsFile}' -f checkstyle" +
+                           $"  --ignore-path '{Args.IgnoreFile}'";
 
             var command = step.PrepareCommand(Args, Result);
 
@@ -42,8 +42,36 @@ namespace Metropolis.Test.Api.Collection.Steps.ECMA
         {
             Args.IgnoreFile = string.Empty; //no ignore path in this example
 
-            var expected = $"{NodeModulesPath}eslint -c '{BaseCollectionStep.LocateSettings("default.eslintrc.json")}' '{Args.SourceDirectory}\\**' "+
-                           $"-o '{Result.MetricsFile}' -f checkstyle";
+            var expected = $"{NodeModulesPath}eslint -c '{BaseCollectionStep.LocateSettings("default.eslintrc.json")}' '{Args.SourceDirectory}'"+
+                           $" --no-eslintrc -o '{Result.MetricsFile}' -f checkstyle ";
+
+            var command = step.PrepareCommand(Args, Result);
+
+            command.Should().Be(expected);
+        }
+
+        [Test]
+        public void ShouldAddJsx_WithReact()
+        {
+            Args.IgnoreFile = string.Empty; //no ignore path in this example
+            Args.EcmaScriptDialect = EslintPasringOptions.REACT;
+
+            var expected = $"{NodeModulesPath}eslint -c '{BaseCollectionStep.LocateSettings("react.eslintrc.json")}' '{Args.SourceDirectory}'" +
+                           $" --no-eslintrc -o '{Result.MetricsFile}' -f checkstyle  --ext .js,.jsx";
+
+            var command = step.PrepareCommand(Args, Result);
+
+            command.Should().Be(expected);
+        }
+
+        [Test]
+        public void ShouldPickupBabelReactConfig_WithBabelReact()
+        {
+            Args.IgnoreFile = string.Empty; //no ignore path in this example
+            Args.EcmaScriptDialect = EslintPasringOptions.BABEL_REACT;
+
+            var expected = $"{NodeModulesPath}eslint -c '{BaseCollectionStep.LocateSettings("babel_react.eslintrc.json")}' '{Args.SourceDirectory}'" +
+                           $" --no-eslintrc -o '{Result.MetricsFile}' -f checkstyle  --ext .js,.jsx";
 
             var command = step.PrepareCommand(Args, Result);
 


### PR DESCRIPTION
I added three new js dialects for ESLint:
React (for any react-development), Babel-react (in case react using babel, like 90% of projects), and node

